### PR TITLE
Add rfc template and v6 repos

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,23 +44,28 @@ The expectations of maintainers are as follows:
 - Create a welcoming environment for new contributors
 - Enforce the [Code Of Conduct](./code-of-conduct.md)
 
-Here are a current list of codebases and their maintainers:
+Dasher v6 is one **shared engine** ([DasherCore](https://github.com/dasher-project/DasherCore)) consumed by several **native frontends**. The current active codebases and their most active contributors are:
 
-- [website](https://github.com/dasher-project/website)
-  - [Will Wade](https://github.com/willwade)
-  - [Gavin Henderson](https://github.com/gavinhenderson5)
-- [dasher-web](https://github.com/dasher-project/dasher-web)
-  - [Jim](https://github.com/sjjhsjjh)
-  - [Jeremy Cope](https://github.com/jcope)
-  - [Gavin Henderson](https://github.com/gavinhenderson5)
-  - [Adam Spickard](https://github.com/aspickard)
-- [dasher-captivewebview](https://github.com/dasher-project/dasher-captivewebview)
-  - [Jim](https://github.com/sjjhsjjh)
-- [dasher-electron](https://github.com/dasher-project/dasher-electron)
-  - [Adam Spickard](https://github.com/aspickard)
-  - [Gavin Henderson](https://github.com/gavinhenderson5)
-- [dasher](https://github.com/dasher-project/dasher)
-  - Unmaintained
+- [DasherCore](https://github.com/dasher-project/DasherCore) — shared C++ engine + C API
+  - [prlw1](https://github.com/prlw1), [ipomoena](https://github.com/ipomoena), [willwade](https://github.com/willwade), [PapeCoding](https://github.com/PapeCoding), [gavinhenderson](https://github.com/gavinhenderson), [cagdasgerede](https://github.com/cagdasgerede)
+- [Dasher-Apple](https://github.com/dasher-project/Dasher-Apple) — iOS / macOS / visionOS (SwiftUI)
+  - [willwade](https://github.com/willwade)
+- [Dasher-Windows](https://github.com/dasher-project/Dasher-Windows) — Windows (Avalonia / .NET)
+  - [willwade](https://github.com/willwade)
+- [Dasher-GTK](https://github.com/dasher-project/Dasher-GTK) — Linux + Win/macOS fallback (GTK4)
+  - [PapeCoding](https://github.com/PapeCoding)
+- [website](https://github.com/dasher-project/website) — [dasher.at](https://dasher.at), docs + public feature status (Astro)
+  - [willwade](https://github.com/willwade), [gavinhenderson](https://github.com/gavinhenderson), [cagdasgerede](https://github.com/cagdasgerede)
+- [dasher-web](https://github.com/dasher-project/dasher-web) — in-browser WASM app
+  - [sjjhsjjh](https://github.com/sjjhsjjh), [jcope](https://github.com/jcope), [willwade](https://github.com/willwade), [agutkin](https://github.com/agutkin), [gavinhenderson](https://github.com/gavinhenderson)
+
+> Formal maintainer and `CODEOWNERS` assignments are being added per-repo (see each repo's `.github/CODEOWNERS`). The lists above show the most active contributors; the steward-confirmed maintainer roster should be finalised here as those land.
+
+**Legacy / maintenance-only:**
+
+- [dasher-captivewebview](https://github.com/dasher-project/dasher-captivewebview) — [Jim](https://github.com/sjjhsjjh)
+- [dasher-electron](https://github.com/dasher-project/dasher-electron) — [Adam Spickard](https://github.com/aspickard), [Gavin Henderson](https://github.com/gavinhenderson)
+- [dasher](https://github.com/dasher-project/dasher) — the original GPL C codebase — **unmaintained** (superseded by DasherCore + the native frontends above)
 
 ## Contributor
 
@@ -114,6 +119,8 @@ An RFC should include the following items:
 - Alternatives
 - Prior Art
 - Unresolved questions
+
+> 💡 A ready-made template and the live index of all RFCs live in the [`rfcs/`](./rfcs) directory of this repository: copy [`rfcs/0000-template.md`](./rfcs/0000-template.md) to get started, and see [`rfcs/README.md`](./rfcs/README.md) for the status of every RFC. For cross-platform UX or hardware interactions especially, an RFC should describe the approach on **each** platform so maintainers can align.
 
 Once you have created the RFC please share it as widely as you can on all communication channels.
 

--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ The expectations of maintainers are as follows:
 - Engage with discussions on Slack
 - Create a welcoming environment for new contributors
 - Enforce the [Code Of Conduct](./code-of-conduct.md)
+- Ensure all merged PRs have DCO sign-off (`Signed-off-by:`)
 
 Dasher v6 is one **shared engine** ([DasherCore](https://github.com/dasher-project/DasherCore)) consumed by several **native frontends**. The current active codebases and their most active contributors are:
 
@@ -73,7 +74,7 @@ A contributor is anyone who contributes to the project. Contributions are not li
 
 Everyone is welcome as a contributor.
 
-There are no expectations, other than all contributions must abide by the [Code Of Conduct](./code-of-conduct.md).
+All contributions must abide by the [Code Of Conduct](./code-of-conduct.md). Code contributions must also be signed off under the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) — see the [contributor guide](https://github.com/dasher-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) for details.
 
 # Funding
 

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,0 +1,56 @@
+---
+rfc: 0000
+title: <short, descriptive title>
+status: proposed          # proposed | active | implemented | rejected | withdrawn
+platforms: [apple, windows, gtk, android, web, core]   # platforms affected
+created: YYYY-MM-DD
+updated: YYYY-MM-DD
+---
+
+# <title>
+
+## Summary
+
+One paragraph explaining the change. What does it do, and at a high level, how?
+
+## Motivation
+
+What problem does this solve? Who feels the pain? Link any issues, user
+feedback, or platform-parity gaps from the [feature matrix](https://dasher.at/status/).
+
+## Detailed design
+
+This is the core of the RFC. Describe the proposed change in enough detail that
+a maintainer on **another** platform could implement their side of it.
+
+For UX or hardware interactions, cover:
+
+- The behaviour from the user's point of view.
+- The DasherCore callback / parameter / API surface used (see [DasherCore's C API](https://github.com/dasher-project/DasherCore/blob/main/docs/C_API.md)).
+- How the UI surface looks on **each** affected platform (Apple / Windows / GTK / Web …) and any platform-specific mapping.
+- Edge cases: what happens when the hardware isn't present, low-memory modes, keyboard extensions, etc.
+
+## Drawbacks
+
+Why might we _not_ want to do this? What's the cost?
+
+## Alternatives considered
+
+What other approaches did you consider, and why is this one better?
+
+## Prior art
+
+Other apps, previous Dasher versions, or other projects that have solved this.
+
+## Unresolved questions
+
+What do you want input on before this is finalised?
+
+## Resolution
+
+_(Filled in once a decision is reached — do not fill in when proposing.)_
+
+- Status: _accepted / rejected_
+- Decided by: _maintainers + stewards_
+- Date: _YYYY-MM-DD_
+- Decision: _short rationale_

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -1,0 +1,38 @@
+# RFCs
+
+This directory holds the Dasher Project's **Requests for Comments** — the
+lightweight design-review process for substantial changes, described in the
+[governance README → Decision making](../README.md#decision-making).
+
+The process is closely based on [Rust's RFC model](https://github.com/rust-lang/rfcs).
+
+## How to propose an RFC
+
+1. Discuss the idea with the community first (Slack / an issue).
+2. Copy [`0000-template.md`](./0000-template.md) to a new file
+   `NNNN-short-name.md` (pick the next free number — `0001`, `0002`, …).
+3. Fill it in. For cross-platform UX/hardware changes, describe the approach on
+   **each** platform so other maintainers can align.
+4. Open a pull request against this repository (or the most relevant repo, if
+   the RFC is single-repo). Share it widely on our comms channels.
+5. Discussion happens on the PR. The author revises in place.
+6. After **at least 7 days**, maintainers + stewards reach consensus and the RFC
+   is marked `active` (accepted) or `rejected`.
+
+## RFC statuses
+
+| Status | Meaning |
+| --- | --- |
+| `proposed` | Drafted, under discussion |
+| `active` | Accepted, ready to implement |
+| `implemented` | The change has landed |
+| `rejected` | Not accepted |
+| `withdrawn` | Author withdrew the proposal |
+
+## Index
+
+| # | Title | Status | Platforms |
+| --- | --- | --- | --- |
+| _0000_ | _(`0000-template.md` — not a real RFC)_ | — | — |
+
+_No RFCs yet. Add yours above this row using the next free number._


### PR DESCRIPTION
## Summary

<!-- What does this change do, and why? Link any issue / RFC. -->

Issue / RFC: #

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Cross-platform / parity change
- [ ] Refactor / tooling / docs

## Cross-platform impact

A core goal of Dasher v6 is **feature parity** across frontends. Help reviewers
see the blast radius:

- [ ] This changes a capability that users see on **other platforms**.
      If checked, I have opened / updated the feature matrix
      (`website/src/data/feature-status.yaml`) — linked PR: #
      _(or confirmed this is genuinely platform-specific-only)_
- [ ] This introduces a **new UX or hardware interaction**.
      If checked, an RFC (`governance/rfcs`) is linked: #

## Definition of Done

- [ ] CI is green (build + tests + lint + format, as applicable)
- [ ] Tests added for new behaviour
- [ ] Feature matrix updated if this affects a cross-platform capability
- [ ] Docs / changelog updated if the change is user-facing
- [ ] Commits are signed off (DCO) — `git commit -s`
