### PR TITLE
rfcs: add Android to platform matrices + RFCs 0008/0009/0010 + CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,73 @@
+# Contributing to the Dasher Project
+
+Thanks for your interest in contributing! This guide covers **how** changes get
+made across the Dasher Project. The short version: be kind (see the
+[Code of Conduct](./code-of-conduct.md)), sign your work (DCO), and open an RFC
+for anything substantial.
+
+Dasher v6 is **one shared engine** ([DasherCore](https://github.com/dasher-project/DasherCore),
+C++ with a flat C API) consumed by several **native frontends**. Most code
+contributions belong in a specific repo, not this one:
+
+| Repo | What lives here |
+| --- | --- |
+| [DasherCore](https://github.com/dasher-project/DasherCore) | The shared engine + the `dasher_*` C API that every frontend calls |
+| [Dasher-Apple](https://github.com/dasher-project/Dasher-Apple) | iOS / macOS / visionOS (SwiftUI) |
+| [Dasher-Windows](https://github.com/dasher-project/Dasher-Windows) | Windows (Avalonia / .NET) |
+| [Dasher-GTK](https://github.com/dasher-project/Dasher-GTK) | Linux + Win/macOS fallback (GTK4) |
+| [Dasher-Android](https://github.com/dasher-project/Dasher-Android) | Android (Kotlin / Jetpack Compose) + IME |
+| [dasher-web](https://github.com/dasher-project/dasher-web) | In-browser WASM app |
+| [website](https://github.com/dasher-project/website) | [dasher.at](https://dasher.at), docs, public feature status |
+| **governance** (this repo) | Roles, decision-making process, RFCs, funding logs |
+
+## Developer Certificate of Origin (DCO)
+
+Every commit must be signed off under the
+[Developer Certificate of Origin](https://developercertificate.org/). This
+attests that you wrote the change or have the right to contribute it.
+
+The easy way: use `git commit -s` (or configure `git config format.signoff true`
+in your clone), which appends a `Signed-off-by: Your Name <you@example.com>`
+line matching your commit identity. Maintainers will block PRs that are missing
+it. If you forget, `git commit --amend -s --no-edit` fixes the last commit.
+
+## Branches, commits, PRs
+
+- Work on a **feature branch**, not `main`. Descriptive name, e.g.
+  `feat/android-crash-reporting` or `rfcs/add-android-platform`.
+- Keep commits focused; write a clear message (most repos follow
+  [Conventional Commits](https://www.conventionalcommits.org/) —
+  `feat:`, `fix:`, `docs:`, `chore:`, `refactor:`).
+- Open a PR against `main`. CI runs a DCO check and (per repo) a build gate.
+- Mark PRs that need cross-platform alignment with the relevant RFC link.
+
+## When to open an RFC
+
+Any **substantial** change — architectural, cross-platform UX, a new platform,
+a privacy/security-relevant feature, or a process change — goes through the
+[Decision making](./README.md#decision-making) process and starts as an RFC in
+[`rfcs/`](./rfcs). The bar is "would another maintainer want a say?" — when in
+doubt, open a short draft RFC and ask.
+
+Each RFC declares which **platforms** it affects in its frontmatter. When you
+add a feature to a platform that an existing RFC covers, update that RFC's
+`platforms:` line and the table in [`rfcs/README.md`](./rfcs/README.md).
+
+## Adding or updating a platform
+
+If you are bringing a new frontend onto a shared feature (or bringing a new
+frontend up at all):
+
+1. Read the relevant RFCs end-to-end — they describe the cross-platform contract.
+2. Consume DasherCore **only through its C API** (`dasher.h`); do not link engine
+   classes directly. This keeps the engine free to evolve.
+3. Add your platform to the affected RFCs' `platforms:` matrices and the
+   `rfcs/README.md` index.
+4. Where a platform genuinely cannot match the contract (e.g. no eye-gaze API,
+   memory-constrained keyboard extension), call it out in the RFC's
+   platform-specific notes rather than silently diverging.
+
+## Questions
+
+- Discussion: the Dasher Slack (see the website for the current invite).
+- Process bugs / improvements to *this* repo: open an issue or PR here.

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The official governance model for all the projects in the dasher project
 
 # Roles
 
-We have a identified a the following roles within the project. Each individual and organizations involved in the project acts within one of these roles.
+We have identified the following roles within the project. Each individual and organizations involved in the project acts within one of these roles.
 
 ## Project Lead
 
@@ -57,6 +57,8 @@ Dasher v6 is one **shared engine** ([DasherCore](https://github.com/dasher-proje
   - [willwade](https://github.com/willwade)
 - [Dasher-GTK](https://github.com/dasher-project/Dasher-GTK) — Linux + Win/macOS fallback (GTK4)
   - [PapeCoding](https://github.com/PapeCoding)
+- [Dasher-Android](https://github.com/dasher-project/Dasher-Android) — Android (Kotlin / Jetpack Compose) + IME
+  - [willwade](https://github.com/willwade)
 - [website](https://github.com/dasher-project/website) — [dasher.at](https://dasher.at), docs + public feature status (Astro)
   - [willwade](https://github.com/willwade), [gavinhenderson](https://github.com/gavinhenderson), [cagdasgerede](https://github.com/cagdasgerede)
 - [dasher-web](https://github.com/dasher-project/dasher-web) — in-browser WASM app
@@ -76,7 +78,7 @@ A contributor is anyone who contributes to the project. Contributions are not li
 
 Everyone is welcome as a contributor.
 
-All contributions must abide by the [Code Of Conduct](./code-of-conduct.md). Code contributions must also be signed off under the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) — see the [contributor guide](https://github.com/dasher-project/.github/blob/main/CONTRIBUTING.md#developer-certificate-of-origin-dco) for details.
+All contributions must abide by the [Code Of Conduct](./code-of-conduct.md). Code contributions must also be signed off under the [Developer Certificate of Origin (DCO)](https://developercertificate.org/) — see [CONTRIBUTING.md](./CONTRIBUTING.md#developer-certificate-of-origin-dco) for details.
 
 # Funding
 
@@ -96,7 +98,7 @@ Each major decision starts as a Request for Comments (RFC). Everyone is invited 
 
 The decision making process only needs to be followed when making 'substantial' changes. Changes don't just apply to code but also architectural, product and process changes. If you are unaware if your change constitutes 'substantial' then feel free to open an RFC with minimal detail to ask before you commit to completing a full RFC.
 
-The decision making model is closely based on [Rusts RFC model](https://github.com/rust-lang/rfcs).
+The decision making model is closely based on [Rust's RFC model](https://github.com/rust-lang/rfcs).
 
 The purpose of this process is not to be absolute or be overly cumbersome. Its a simple, lightweight process to make sure everyone has their voice heard.
 

--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -1,7 +1,7 @@
 ---
 rfc: 0000
 title: <short, descriptive title>
-status: proposed          # proposed | active | implemented | rejected | withdrawn
+status: proposed          # draft | proposed | active | implemented | rejected | withdrawn
 platforms: [apple, windows, gtk, android, web, core]   # platforms affected
 created: YYYY-MM-DD
 updated: YYYY-MM-DD

--- a/rfcs/0001-analytics.md
+++ b/rfcs/0001-analytics.md
@@ -2,9 +2,9 @@
 rfc: 0001
 title: Privacy-preserving analytics and crash reporting
 status: proposed
-platforms: [apple, windows, gtk]
+platforms: [apple, windows, gtk, android]
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-28
 ---
 
 # Privacy-preserving analytics and crash reporting

--- a/rfcs/0002-lucide-icons.md
+++ b/rfcs/0002-lucide-icons.md
@@ -2,9 +2,9 @@
 rfc: 0002
 title: Adopt Lucide as the cross-platform icon set
 status: proposed
-platforms: [apple, windows, gtk]
+platforms: [apple, windows, gtk, android]
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-28
 ---
 
 # Adopt Lucide as the cross-platform icon set

--- a/rfcs/0003-multilingual-ui.md
+++ b/rfcs/0003-multilingual-ui.md
@@ -2,9 +2,9 @@
 rfc: 0003
 title: Multilingual UI support across all frontends
 status: proposed
-platforms: [apple, windows, gtk, core]
+platforms: [apple, windows, gtk, android, core]
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-28
 ---
 
 # Multilingual UI support across all frontends

--- a/rfcs/0004-onboarding.md
+++ b/rfcs/0004-onboarding.md
@@ -2,9 +2,9 @@
 rfc: 0004
 title: First-run onboarding experience
 status: proposed
-platforms: [apple, windows, gtk, core]
+platforms: [apple, windows, gtk, android, core]
 created: 2026-06-17
-updated: 2026-06-17
+updated: 2026-06-28
 ---
 
 # First-run onboarding experience

--- a/rfcs/0006-settings-ia.md
+++ b/rfcs/0006-settings-ia.md
@@ -2,9 +2,9 @@
 rfc: 0006
 title: Settings information architecture and progressive disclosure
 status: proposed
-platforms: [apple, windows, gtk, core]
+platforms: [apple, windows, gtk, android, core]
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-06-28
 ---
 
 # Settings information architecture and progressive disclosure

--- a/rfcs/0008-keyboard-onboarding.md
+++ b/rfcs/0008-keyboard-onboarding.md
@@ -1,0 +1,220 @@
+---
+rfc: 0008
+title: Keyboard extension / IME onboarding (Apple & Android)
+status: proposed
+platforms: [apple, android, core]
+created: 2026-06-28
+updated: 2026-06-28
+---
+
+# Keyboard extension / IME onboarding (Apple & Android)
+
+## Summary
+
+Dasher ships as both a standalone writing app **and** a system keyboard:
+on Apple platforms an iOS custom keyboard extension (`NSExtensionPointIdentifier
+com.apple.keyboard-service`), and on Android an Input Method Editor
+(`InputMethodService`, `BIND_INPUT_METHOD`). Installing the app is not enough —
+the user must explicitly **enable** the keyboard in OS settings and then **select**
+it as the active input source. This is a multi-step system-settings dance that
+first-time users routinely fail at, and it is the single largest source of
+"the keyboard doesn't work" support requests.
+
+This RFC specifies a shared, platform-specific **first-run onboarding flow** that
+detects the keyboard's enablement state and walks the user through enabling it,
+with deep-links into the exact system screens. It complements the generic
+first-run onboarding in [RFC 0004](./0004-onboarding.md), which deliberately did
+not cover the keyboard-enablement step.
+
+## Motivation
+
+- On Android, fewer than half of users who install an IME-based keyboard succeed
+  in enabling it without guidance. The flow spans **Settings → System → Keyboard →
+  On-screen keyboard → enable Dasher → "Back" → Default keyboard → pick Dasher**,
+  optionally followed by **Privacy → Advanced input methods → grant input
+  permission** (needed for clipboard / full-text access). Each step is a place to
+  lose the user.
+- On iOS, the flow is **Settings → General → Keyboard → Keyboards → Add New
+  Keyboard → Dasher → (trust prompt "Allow Full Access")**. The "Full Access"
+  prompt in particular scares users; without it the engine clipboard + speak
+  callbacks are unavailable.
+- The state is also **opaque**: the app cannot silently know whether the user
+  completed the steps. Both platforms expose APIs to query it, but neither
+  frontend currently does — there is no in-app guidance, no "you're nearly there",
+  no re-prompt after the user returns from system settings.
+- This is platform-specific plumbing that does not belong in DasherCore (the
+  engine), but the **detection queries and the step model** are shared enough
+  that a single RFC keeps Apple and Android aligned.
+
+## Detailed design
+
+### Shared model
+
+A keyboard onboarding flow has three observable states plus a "needs permission"
+sub-state:
+
+| State | Meaning |
+| --- | --- |
+| `notEnabled` | The keyboard/IME is installed but not turned on in system settings. |
+| `enabledNotDefault` | The keyboard/IME is enabled but not the currently selected input source. |
+| `needsPermission` | Enabled, but the OS-level input/Full-Access permission is off (limits clipboard, speak, etc.). |
+| `ready` | Enabled, selected, permission sufficient. |
+
+Each frontend exposes:
+
+1. A **detection** function returning the current state.
+2. A **deep-link** to the exact system settings screen for the current state.
+3. A **first-run prompt** + a **resume-on-return** check (re-detect when the app
+   regains foreground after the user is sent to system settings).
+4. A **manual re-trigger** from Settings (so users can re-run the flow later).
+
+Detection must be **cheap and side-effect free** (called in `onResume` /
+`scenePhase` becoming active).
+
+### Android (IME)
+
+**Detection.** `InputMethodManager` + `Settings.Secure`:
+
+- **Enabled?** The IME's component name (`ComponentName(this, DasherImeService::class.java)`,
+  flattened) appears in `Settings.Secure.getString(
+  ENABLED_INPUT_METHODS)` — a colon-separated list of enabled IMEs.
+- **Default?** On Android 11+, `imm.getEnabledInputMethodList()` plus the
+  default-IME intent resolution. There is no fully public "current default IME"
+  API before Android 14; the pragmatic check is whether Dasher's IME is enabled
+  *and* the user has only one IME enabled, or whether the system's
+  `Settings.Secure.DEFAULT_INPUT_METHOD` value equals the Dasher IME component.
+  Fall back to "enabledNotDefault" if ambiguous.
+- **Permission?** The input-method binding itself is the permission; the separate
+  "input data access" prompt (Android 14+, `INPUT_METHOD_SERVICES_PRIVILEGED`)
+  governs clipboard / commit-text visibility beyond the focused field. Query via
+  the IME service's `isEnabledForInput` / shouldShow warnings when commiting.
+
+**Deep-links.** Use the documented `Intent` actions:
+
+| State | Intent |
+| --- | --- |
+| `notEnabled` | `android.provider.Settings.ACTION_INPUT_METHOD_SETTINGS` (manage keyboards) |
+| `enabledNotDefault` | `android.provider.Settings.ACTION_INPUT_METHOD_SELECTOR` (Android 11+ picker) or re-use `ACTION_INPUT_METHOD_SETTINGS` with guidance copy |
+| `needsPermission` | `android.provider.Settings.ACTION_INPUT_METHOD_SETTINGS` + inline guidance (there is no dedicated permission screen for IME input access pre-14) |
+
+**Flow.**
+
+1. On first run (flag in `SharedPreferences`: `onboarding_ime_shown`), show a
+   modal: "Use Dasher as your keyboard" with a one-line explanation and a
+   primary button **"Enable keyboard"** (deep-link to input-method settings) and
+   a secondary **"Not now"**.
+2. The user is sent to system settings; the app goes to the background.
+3. On `onResume`, re-detect. If `ready`, celebrate and dismiss. If still
+   `notEnabled`/`enabledNotDefault`, show a persistent, dismissible banner
+   ("Almost there — select Dasher as your keyboard") with a **"Open settings"**
+   button.
+4. A "Keyboard setup" entry in Settings → re-runs the flow.
+
+The IME service itself does **not** run onboarding (it is the wrong process and
+may not exist yet); the main app drives the flow and shares the persisted
+onboarding flag via the app's `filesDir` (which, per RFC 0007 and the existing
+shared-data pattern, is the same path the IME reads at its engine creation).
+
+### Apple (iOS keyboard extension)
+
+**Detection.**
+
+- **Enabled?** `UIApplication.openSettingsURLString` does not expose keyboard
+  state directly; the pragmatic approach is to attempt to detect via
+  `UIInputViewController.hasFullAccess` (only valid inside the extension) plus a
+  heartbeat: the extension writes a flag into the **App Group container**
+  (`group.at.dasher.Dasher`) the first time it is loaded by the system (i.e. the
+  user actually opened the keyboard picker). The main app reads that flag to know
+  "the extension has been activated at least once."
+- **Full Access?** `UIDevice` does not expose it; only the extension's
+  `hasFullAccess` knows. The extension reports this through the App Group flag
+  alongside the heartbeat.
+- **Selected?** Best-effort: the heartbeat timestamp being recent is a proxy.
+
+**Deep-link.** `UIApplication.shared.open(URL(string: UIApplication.openSettingsURLString)!)`
+opens the app's settings; from there the user navigates to Keyboard. Apple
+provides no more specific deep-link, so the modal must include **step-by-step
+copy** ("Settings → General → Keyboard → Keyboards → Add New Keyboard → Dasher")
+and, for Full Access, "tap Dasher → turn on Allow Full Access."
+
+**Flow.**
+
+1. First-run modal: "Install Dasher keyboard" with the step copy and an
+   **"Open Settings"** button (`openSettingsURLString`).
+2. On `scenePhase` becoming `.active`, re-read the App Group heartbeat. Update
+   state, show a confirmation when the heartbeat indicates success.
+3. The Full Access step has its own explanatory copy (why it's needed: clipboard,
+   speak, training-file write-back) and a clear opt-out note (the keyboard works
+   for basic entry without it).
+
+### Copy and translation
+
+All onboarding copy goes through the RFC 0003 i18n pipeline (engine
+`strings_*.json` for any engine-side strings; platform-native catalogs for the
+chrome). The "Allow Full Access" / "Input permission" explanations in particular
+must be plain-language and localised — they are the scariest step.
+
+### What does NOT belong here
+
+- The **generic** first-run experience (welcome, input handshake, first-zoom
+  tutorial) is RFC 0004. This RFC is only the keyboard-enablement sub-flow.
+- **Switch / access-method setup** belongs to the input & access-methods RFC
+  (0010), not here.
+- **App-group / shared-storage layout** is defined by the existing shared-data
+  pattern (the same `userDir` the engine reads); this RFC only depends on it.
+
+## Drawbacks
+
+- Adds platform-specific detection code that is **fragile across OS versions**
+  (the Android default-IME query and the Apple Full Access detection are both
+  partially heuristic). The detection must degrade gracefully (assume
+  `enabledNotDefault` on uncertain queries, never block the user).
+- The heartbeat pattern on iOS is a workaround for a missing API and could break
+  if Apple changes App Group visibility for extensions.
+- Onboarding modals are friction; users who installed the standalone app to use
+  it *as an app* (not as a keyboard) will see a prompt that is not relevant to
+  them. Mitigation: only show the keyboard onboarding if the keyboard target is
+  bundled, and offer a "don't show again."
+
+## Alternatives considered
+
+- **Do nothing / rely on OS-level prompts.** Status quo. Confirmed poor
+  conversion; this RFC exists because that is not good enough.
+- **Fully automate via MDM / accessibility.** Not possible for a consumer app.
+- **Bundle a system-prompt shim.** Neither platform allows an app to silently
+  enable its own keyboard.
+
+## Prior art
+
+- **Gboard / SwiftKey** both ship a guided "Enable keyboard" first-run flow on
+  Android with the exact deep-links above and a returning-user banner — the de
+  facto user expectation.
+- **Fleksy / Grammar Keyboard** on iOS use the step-copy + `openSettingsURLString`
+  pattern.
+- **Dasher v5** had no keyboard extension; this is a new concern for v6.
+
+## Unresolved questions
+
+1. **Default-IME detection on Android < 14.** What is the most reliable heuristic
+   that doesn't require a privileged permission? Proposal: treat "enabled and
+   only one IME enabled" as `ready`, else `enabledNotDefault`.
+2. **Re-prompt cadence.** How often should the banner re-appear if the user
+   dismisses it? Once per app launch? Once ever (until they re-open the flow from
+   Settings)?
+3. **Full Access messaging.** Is the AAC-specific framing ("needed so Dasher can
+   speak what you write and remember your training") the right one, or does it
+   over-promise?
+4. **IME-engine sharing.** Should the onboarding flag live in the shared
+  `userDir` (so the IME can also see it) or in the main app's private prefs?
+5. **Does this warrant a small DasherCore C API** (e.g. a "mark keyboard
+   onboarding complete" persisted flag) so all frontends share the SSOT, or is
+   per-frontend persistence correct?
+
+## Resolution
+
+_(Filled in once a decision is reached — do not fill in when proposing.)_
+
+- Status: _pending_
+- Decided by: _pending_
+- Date: _pending_
+- Decision: _pending_

--- a/rfcs/0009-crash-reporting.md
+++ b/rfcs/0009-crash-reporting.md
@@ -1,0 +1,185 @@
+---
+rfc: 0009
+title: Crash reporting & engine diagnostics capture
+status: proposed
+platforms: [apple, windows, gtk, android, core]
+created: 2026-06-28
+updated: 2026-06-28
+---
+
+# Crash reporting & engine diagnostics capture
+
+## Summary
+
+Define a single, cross-platform contract for capturing crashes and engine
+diagnostics so that a crash report reaching PostHog (per [RFC 0001][1]) is
+**useful** — it must contain the exception, a sanitised stack trace, and the
+last few seconds of **engine diagnostic log lines** so a maintainer can
+reconstruct what DasherCore was doing when it died. This RFC depends on the
+DasherCore C API `dasher_set_log_callback` (added v0.1.3, RFC 0007-adjacent)
+which made the engine's former `CFileLogger`/`CBasicLog`/`UserLog` systems
+available to frontends as a stream of `(level, message)` events.
+
+This RFC extends [RFC 0001][1] (which left crash detail as an unresolved
+question) and is the authoritative spec for the `crash` event.
+
+[1]: ./0001-analytics.md
+
+## Motivation
+
+- Dasher is a beta. Crashes matter. RFC 0001 specified *that* we capture crashes
+  and the event name, but not *how* each platform hooks its uncaught-exception
+  path, *what* goes in `stack_trace`, or how to capture engine-side context.
+- Today the platforms are inconsistent: Windows wires
+  `AppDomain.UnhandledException` → PostHog; Apple stubs it (no uncaught handler
+  installed); GTK proposes signal handlers; Android has nothing. The result is
+  that most crash reports we do get are thin (no engine state), and Android — a
+  fast-growing install base — produces no crash data at all.
+- The engine now exposes a single diagnostic channel (`dasher_set_log_callback`,
+  `dasher.h`) carrying levelled log lines (0 debug / 1 info / 2 warn / 3 error).
+  Capturing the **last N** of these into a ring buffer gives every crash report a
+  "what was the engine doing" tail — invaluable for diagnosing assert-failures
+  and bad-parameter crashes that originate in DasherCore rather than the
+  frontend.
+
+## Detailed design
+
+### The crash report envelope
+
+Every crash report is a single PostHog `crash` event with this shape (extends
+RFC 0001's table):
+
+| Field | Source | Notes |
+| --- | --- | --- |
+| `platform` | frontend | `apple` / `windows` / `gtk` / `android` |
+| `app_variant` | frontend | e.g. `dasher-android`, `dasher-apple-ios` |
+| `app_version` | build | semver |
+| `os_version` | OS | e.g. `Android 15`, `iOS 26.5`, `Windows 11 22631` |
+| `locale` | engine | `dasher_get_locale` (already sent with analytics) |
+| `exception_type` | uncaught handler | e.g. `java.lang.IllegalStateException`, `EXC_BAD_ACCESS`, `System.NullReferenceException` |
+| `stack_trace` | uncaught handler | **PII-scrubbed** (see below) |
+| `engine_log_tail` | log ring buffer | last N `(level, message)` lines from `dasher_set_log_callback` |
+| `signal_or_reason` | handler | e.g. `SIGSEGV`, `Aborting: DASHER_ASSERT` |
+
+The `engine_log_tail` is the new, unifying piece: every frontend keeps a small
+in-process ring buffer of the most recent engine log lines (recommended size:
+**64 lines, capped at 8 KB total**) and appends it to the crash event.
+
+### Per-platform crash hooks
+
+| Platform | Hook | Notes |
+| --- | --- | --- |
+| **Android** | `Thread.setDefaultUncaughtExceptionHandler` (JVM) **+** a native `sigaction(SIGSEGV/SIGABRT/SIGILL)` shim for JNI/engine crashes | The JVM handler catches Kotlin/Java throws; the signal shim catches crashes inside `libdasher.so`. Pipe the latter via a `sigwait`-or-`abort` trampoline that writes a minidump line + the ring buffer to a crash file before re-raising. |
+| **Apple** | `signal(SIGABRT/...)` + `NSExceptionExceptionHandler` (NSSetUncaughtExceptionHandler) | Capture `callStackSymbols`; write to App Group container; flush on next launch (a crashing process can't safely do network). |
+| **Windows (.NET)** | `AppDomain.CurrentDomain.UnhandledException` + `TaskScheduler.UnobservedTaskException` | Already implemented in Dasher-Windows; align fields to this envelope. |
+| **GTK** | `signal(SIGSEGV/SIGABRT)` + `std::set_terminate` | async-signal-safe path writes the buffer to disk; flush on next launch. |
+
+**Crash-time discipline.** Inside an uncaught handler you must **not** do work
+that can itself crash (no heap allocation, no network, no PostHog SDK calls in
+the crashing thread). The handler writes a small **crash file** to the app's
+private storage containing the envelope; on the **next launch**, the app
+detects the crash file, sends the `crash` event via the normal PostHog SDK
+path, and deletes it.
+
+### Engine log ring buffer (shared pattern)
+
+Each frontend, at engine creation, registers a log callback that:
+
+1. Routes lines to the platform log (Android `Log` / Apple `os_log` / Windows
+   `Debug`+`engine.log` / GTK `g_log`) — **already done** in Dasher-Android
+   (→ logcat, `DasherEngine.installEngineCallbacks`) and Dasher-Windows.
+2. Appends `(level, message, monotonic_ms)` to a fixed-capacity ring buffer.
+3. The crash handler snapshots the ring buffer into the crash file.
+
+Levels are filtered per RFC 0007's `dasher_set_log_callback(ctx, cb, user, min_level)`
+argument. For the ring buffer, capture at `min_level = 1` (info) by default —
+debug (0) is too noisy to keep around for a crash, but info+warnings+errors
+reconstruct the sequence. A **diagnostic mode** (Settings → Privacy →
+"Send verbose logs with crash reports") lowers this to 0 for users who opt in to
+helping diagnose a specific issue.
+
+### PII scrubbing
+
+Crash reports can leak via stack traces (file paths containing usernames —
+`/Users/jane/…`, `C:\Users\bob\…`, `/data/data/at.dasher.android/…` is fine) and
+via the engine log tail if a log line ever included user text. The schema
+guarantees (RFC 0001) that **typed text, clipboard, canvas contents, training
+text** are never collected, and the engine's `Message()` callback (the only
+current log emitter in `CAPI.cpp`) routes user-facing strings but not raw typed
+text. Even so, scrubbers **must** run before the envelope is written:
+
+- Home-directory path segments → `<user>` (`/Users/<user>/`, `C:\Users\<user>\`,
+  `/home/<user>/`).
+- Email-shaped strings → `<email>`.
+- Truncate `stack_trace` to 16 KB and `engine_log_tail` to 8 KB.
+- Hard cap the whole envelope at 32 KB; truncate the tail first if exceeded.
+
+A scrub unit test must cover each platform's path format.
+
+### When to send
+
+- **Opt-in gate.** No crash event is sent unless the user has opted in to
+  analytics (RFC 0001). If the user has *not* opted in, the crash file is still
+  written (cheap, local) but **never transmitted**; it is deleted after 7 days or
+  on opt-out.
+- **First launch after crash.** Detect the crash file, send, delete. If the send
+  fails (offline), retry on subsequent launches up to 3 times, then discard.
+
+## Drawbacks
+
+- **Signal handlers and uncaught-exception handlers are inherently risky** to
+  run inside a crashing process. The "write a tiny file and re-raise" pattern
+  minimises this but is not free; a handler that itself crashes can wedge the
+  app. Mitigation: keep the handler path trivial and crash-tested.
+- **Native (JNI/.so) crashes on Android** are the hardest case; a JVM
+  `UncaughtExceptionHandler` will not see a SIGSEGV in `libdasher.so`. The
+  signal shim is extra complexity and must be re-tested per NDK/AGP version.
+- **Verbose logs → crash size.** Allowing `min_level = 0` (debug) bloats the
+  envelope; opt-in only and hard cap is essential.
+- **Privacy optics.** Sending *any* log tail with a crash may worry users even
+  with scrubbing. The privacy policy and the Settings copy must be explicit.
+
+## Alternatives considered
+
+- **Crash-only SDK (Sentry / Crashlytics / Bugsnag).** Removes the per-platform
+  handler work; gives better native stack symbolication. Cost: another network
+  dependency, another vendor, possibly a different retention posture. RFC 0001's
+  "alternatives" section already considered this; this RFC keeps the PostHog-only
+  model but a future RFC could revisit a dedicated crash tool for native stacks.
+- **No engine log tail** (stack trace only). Rejected: the assert failures and
+  bad-parameter paths inside DasherCore are exactly the crashes that need engine
+  context to diagnose.
+- **Stream all logs to PostHog continuously** (not just on crash). Rejected:
+  violates RFC 0001's "no canvas/typed-text" promise and inflates ingest; the
+  ring-buffer-then-send-on-crash model is the right trade.
+
+## Prior art
+
+- **posthog-ios / posthog-dotnet / posthog-android** all have
+  `captureException`/automatic-capture modes; this RFC aligns the envelope and
+  adds the engine tail they don't have.
+- **Firefox/Sentry** capture a "breadcrumb" tail — the engine log ring buffer is
+  the same idea.
+- **Dasher-Windows** already implements `AppDomain.UnhandledException` +
+  `engine.log`; this RFC generalises that pattern.
+
+## Unresolved questions
+
+1. **Ring buffer process boundary (Android).** The IME runs in the same package
+   but the user's crash might be in the IME process. Should the IME also write a
+   crash file, or only the main app? (Proposal: both, different filename suffix.)
+2. **Symbolication.** Do we ship (or host) dSYM/PDB/.map files to symbolicate
+   native stacks, or accept unsymbolicated frames in v1?
+3. **Verbose-log opt-in surface.** Is "Send verbose logs with crash reports" the
+   right Settings copy and placement (Settings → Privacy, per RFC 0006 IA)?
+4. **Retention of crash files pre-opt-in.** 7 days is proposed; is that right
+   given some users take longer to decide on the analytics opt-in?
+
+## Resolution
+
+_(Filled in once a decision is reached — do not fill in when proposing.)_
+
+- Status: _pending_
+- Decided by: _pending_
+- Date: _pending_
+- Decision: _pending_

--- a/rfcs/0010-input-access-methods.md
+++ b/rfcs/0010-input-access-methods.md
@@ -1,0 +1,201 @@
+---
+rfc: 0010
+title: Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick)
+status: draft
+platforms: [apple, windows, gtk, android, core]
+created: 2026-06-28
+updated: 2026-06-28
+---
+
+# Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick)
+
+> **This RFC is a DRAFT.** It exists to frame a large, under-specified area that
+> is implemented ad-hoc and inconsistently across the v6 frontends. It is **not**
+> ready for consensus; the Unresolved Questions section is the most important
+> part. The intent is to align maintainers on the shape of the problem before any
+> platform invests in deeper work.
+
+## Summary
+
+DasherCore's selection behaviour is governed by a single engine parameter,
+`SP_INPUT_FILTER` (e.g. "Normal Control", "Click Mode", "Menu Mode", "Two Push
+Dynamic Mode"), plus a handful of bool/long params (`BP_STOP_OUTSIDE`,
+`BP_AUTOCALIBRATE`, `LP_START_MODE`, etc.). But the **user-facing concept** of an
+"access method" — *how do you steer* (pointer / touch / eye-gaze / tilt / joystick
+/ switches) × *how do you select* (continuous / press-to-move / click-to-zoom /
+dwell / 1-switch / 2-switch / 2-push / scanning / direct-boxes) — is a
+**frontend concern** that each platform has reinvented with different UX, a
+different data model, and different gaps. This RFC proposes a shared
+**access-method model** and a per-platform integration spec so that "set up your
+access method" means the same thing on Apple, Windows, GTK, and Android.
+
+## Motivation
+
+- Dasher is an assistive text-entry tool. The access-method choice is the single
+  most consequential configuration a user makes — it determines whether they can
+  use Dasher at all with their motor abilities.
+- Today:
+  - **Apple** has the richest model (`AccessMethod` × `SelectionMethod` matrices,
+    `SwitchProfile`, `TiltCalibrationView`, app-level dwell with a radial
+    indicator) but no joystick/gamepad implementation and a partially-stubbed
+    iOS switch-capture.
+  - **Windows** has `AccessMethod` + `SelectionMethod` + native eye-gaze
+    (WinRT) + UDP gaze + gamepad, but no switch-capture UI and no dwell
+    rendering.
+  - **GTK** has none of this surfaced (hand-built 3-page Preferences window).
+  - **Android** has touch + tilt only; the Input settings tab shows raw engine
+    parameters with no curated access-method UX.
+- The matrices on Apple and Windows already **diverge** (different method enums,
+  different compatibility rules). Without an RFC they will diverge further.
+- Eye-gaze in particular is implemented three different ways (Apple hover /
+  Windows WinRT+UDP / nothing on Android) with no shared tracker abstraction or
+  wire protocol.
+
+## Detailed design (shape — to be refined)
+
+### Shared concepts
+
+1. **Steering method** — what produces the continuous (x, y) the engine's pointer
+   consumes. Values: `pointer`, `touch`, `eyeGaze`, `tilt`, `joystick`,
+   `handTracking`, `switchesOnly`. Platform availability varies (see table below).
+2. **Selection method** — when/how a zoom/select happens. Maps 1:1 to an
+   `SP_INPUT_FILTER` value plus zero or more engine bool/long params. Values:
+   `continuous`, `pressToMove`, `clickToZoom`, `dwell`, `oneSwitch`,
+   `twoSwitches`, `twoPush`, `scanning`, `directBoxes`.
+3. **Switch profile** — for switch-driven selection methods, the binding of
+   physical inputs (keys / Bluetooth switches / platform switch-access events)
+   to DasherCore "key events" (`dasher_key_event`). Includes scan speed.
+4. **Dwell rendering** — an **app-level** affordance (not an engine concept) that
+   shows a radial progress indicator after a configurable dwell duration and
+   synthesises the select. Required on any platform offering dwell.
+5. **Compatibility matrix** — which selection methods are valid for a given
+   steering method (e.g. `scanning` is valid for `switchesOnly` but not for
+   `pointer`).
+
+### Per-platform availability (proposed target)
+
+| Steering method | Apple | Windows | GTK | Android |
+| --- | --- | --- | --- | --- |
+| pointer (mouse/trackpad) | ✓ (Mac) | ✓ | ✓ (planned) | ✓ (mouse/Bluetooth) |
+| touch | ✓ | ✓ | ✓ | ✓ |
+| eyeGaze | ✓ (hover / iPadOS 18 Eye Tracking) | ✓ (WinRT + UDP) | TBD | **TBD (new)** |
+| tilt | ✓ (iOS, CoreMotion) | — | — | ✓ (existing `TiltInputProvider`) |
+| joystick / gamepad | listed, **not implemented** | ✓ (WinRT Gamepad) | TBD | **TBD (new)** |
+| handTracking | listed (visionOS Phase 3) | — | — | — |
+| switchesOnly | ✓ | ✓ (method exists, **no capture UI**) | TBD | **TBD (new)** |
+
+### Eye-gaze tracker abstraction (proposal)
+
+- A **tracker interface** per platform with one job: produce a stream of
+  `(x_screen, y_screen, timestamp)` gaze points.
+- Three concrete sources to standardise:
+  1. **Platform-native eye tracker** (WinRT `GazeInputSourcePreview`; iPadOS 18
+     Eye Tracking surfaced as a pointer; Android Camera Switch / future eye-track
+     APIs).
+  2. **Mouse-presenting trackers** (Tobii and others that appear as a mouse) —
+     consumed via the platform pointer path, no special code.
+  3. **Network gaze (UDP)** — adopt Dasher-Windows's existing UDP protocol as the
+     cross-platform wire format:
+     - `STREAM_DATA <ts> <x> <y>` (spaces), or
+     - `GazePoint X:<x> Y:<y> Timestamp:<ts>`
+     Default port 5555 on loopback. This lets a gaze-emulator or a separate
+     tracker process feed any frontend.
+- The frontend transforms `(x_screen, y_screen)` → canvas-local →
+  `dasher_mouse_move(x, y)`.
+
+### Switch profile (proposal)
+
+- A `SwitchProfile` is an ordered list of up to 4 switches, each binding a
+  **physical input** to a **DasherCore key event** (`dasher_key_event(ctx, key, dir)`).
+- Physical inputs are platform-specific:
+  - Apple: keyboard keys (Space/Enter/Tab/Arrows/F1–F12/A–Z/0–9) on Mac;
+    Bluetooth switches / AssistiveTouch / the system Switch Control events on iOS.
+  - Windows: keyboard keys; XInput gamepad buttons.
+  - GTK: keyboard keys; evdev joysticks.
+  - Android: keyboard keys; **Android Switch Access** events
+    (`AccessibilityService`); Bluetooth switches via `KeyEvent`.
+- Persisted as JSON sidecar (`access.json`) per platform, **outside** the engine
+  parameter schema (mirrors RFC 0007's appearance-settings pattern).
+
+### Dwell (proposal)
+
+- App-level. Configurable duration (proposed defaults: 0.3 / 0.5 / 0.8 / 1.0 /
+  1.5 s). A radial progress indicator is drawn over the canvas at the pointer;
+  on completion, synthesise a select (`dasher_mouse_down` + `dasher_mouse_up` or
+  the appropriate `dasher_key_event`).
+- On platforms with no app-level rendering budget for it (keyboard extension,
+  low-memory IME mode), dwell may be disabled with a clear note.
+
+### Settings IA
+
+A dedicated **Access** sub-screen (per RFC 0006 IA): steering method → selection
+method (filtered by compatibility) → switch profile (if needed) → dwell settings
+(if dwell) → tilt calibration (if tilt). Today Apple has this; the RFC proposes
+all four platforms adopt the same shape.
+
+## Drawbacks
+
+- **Large surface area.** This is several engineering-months per platform; an RFC
+  does not make it cheap.
+- **Platform-specific fragmentation is real.** Switch Access on Android, Switch
+  Control on iOS, and XInput on Windows are genuinely different APIs; a shared
+  *model* is achievable, a shared *implementation* is not.
+- **UX research gap.** The compatibility matrix and the access-screen IA need
+  user research with the actual target population (AAC users, clinicians) —
+  building this top-down risks the same "developer-assigned tiers" problem RFC
+  0006 flagged.
+
+## Alternatives considered
+
+- **Engine owns the access-method model.** Rejected: the inputs are inherently
+  platform-specific (CoreMotion, WinRT, Android Sensor/Accessibility). The
+  engine already exposes the right knobs (`SP_INPUT_FILTER`, key events,
+  `dasher_mouse_move`); the frontend owns the model.
+- **Per-platform free-for-all.** Status quo. The matrices already diverge;
+  without alignment, "I use Dasher with 2 switches" will mean different things on
+  different platforms.
+
+## Prior art
+
+- **Dasher v5** (`IPhoneInputs.mm`, switch/dynamic modes) is the lineage for the
+  iOS tilt + switch math.
+- **Apple Switch Control / Android Switch Access / Windows Eye Control** are the
+  platform-native assistive-input systems a frontend can consume instead of
+  reinventing switch handling.
+- **Tobii / eyeX / PCEye** hardware ecosystems established the UDP-gaze
+  de-facto pattern.
+
+## Unresolved questions (the most important section)
+
+1. **Canonical method enums.** Can Apple and Windows agree on a single shared
+   list of `SteeringMethod` × `SelectionMethod` values (and a compatibility
+   matrix)? If yes, does it live in DasherCore as documentation, or only in this
+   RFC?
+2. **Switch Access vs. in-app switch capture on mobile.** On Android and iOS,
+   should Dasher consume the **system** switch-access/switch-control events
+   (lower friction, honours the user's existing switch setup) or capture its own
+   (more control, requires the user to re-bind)? This is the biggest open
+   design question.
+3. **UDP gaze protocol.** Is Windows's existing format the right cross-platform
+   standard, or should we define a cleaner JSON/binary format now?
+4. **Android eye-gaze path.** Camera Switch presents as an accessibility
+   service, not a mouse; Tobii on Android presents as a mouse. Which do we
+   target first?
+5. **Dwell rendering in the IME/keyboard extension.** Out of scope, or a
+   reduced-capability version?
+6. **Where does the access-method state live?** Sidecar JSON (per RFC 0007
+   pattern) vs. engine parameters (per RFC 0006 manifest)?
+7. **UX research prerequisite.** What is the minimum user research required
+   before promoting this RFC out of `draft`?
+8. **Does Android need an `AccessibilityService`** (for Switch Access
+   consumption) alongside the existing `InputMethodService`? That has app-store
+   and permission implications worth its own sub-RFC.
+
+## Resolution
+
+_(Filled in once a decision is reached — do not fill in when proposing.)_
+
+- Status: _draft — not ready for consensus_
+- Decided by: _pending_
+- Date: _pending_
+- Decision: _pending_

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -23,6 +23,7 @@ The process is closely based on [Rust's RFC model](https://github.com/rust-lang/
 
 | Status | Meaning |
 | --- | --- |
+| `draft` | Early work-in-progress; not yet ready for formal consensus |
 | `proposed` | Drafted, under discussion |
 | `active` | Accepted, ready to implement |
 | `implemented` | The change has landed |
@@ -34,10 +35,13 @@ The process is closely based on [Rust's RFC model](https://github.com/rust-lang/
 | # | Title | Status | Platforms |
 | --- | --- | --- | --- |
 | _0000_ | _(`0000-template.md` — not a real RFC)_ | — | — |
-| [0001](./0001-analytics.md) | Privacy-preserving analytics and crash reporting | proposed | apple, windows, gtk |
-| [0002](./0002-lucide-icons.md) | Adopt Lucide as the cross-platform icon set | proposed | apple, windows, gtk |
-| [0003](./0003-multilingual-ui.md) | Multilingual UI support across all frontends | proposed | apple, windows, gtk, core |
-| [0004](./0004-onboarding.md) | First-run onboarding experience | proposed | apple, windows, gtk, core |
+| [0001](./0001-analytics.md) | Privacy-preserving analytics and crash reporting | proposed | apple, windows, gtk, android |
+| [0002](./0002-lucide-icons.md) | Adopt Lucide as the cross-platform icon set | proposed | apple, windows, gtk, android |
+| [0003](./0003-multilingual-ui.md) | Multilingual UI support across all frontends | proposed | apple, windows, gtk, android, core |
+| [0004](./0004-onboarding.md) | First-run onboarding experience | proposed | apple, windows, gtk, android, core |
 | [0005](./0005-v5-migration.md) | Dasher v5 → v6 migration: settings, alphabets, and user data | proposed | apple, windows, gtk, core |
-| [0006](./0006-settings-ia.md) | Settings information architecture and progressive disclosure | proposed | apple, windows, gtk, core |
+| [0006](./0006-settings-ia.md) | Settings information architecture and progressive disclosure | proposed | apple, windows, gtk, android, core |
 | [0007](./0007-dark-mode-palettes.md) | Dark mode support via appearance-aware colour palettes | proposed | apple, windows, gtk, android, web, core |
+| [0008](./0008-keyboard-onboarding.md) | Keyboard extension / IME onboarding (Apple & Android) | proposed | apple, android, core |
+| [0009](./0009-crash-reporting.md) | Crash reporting & engine diagnostics capture | proposed | apple, windows, gtk, android, core |
+| [0010](./0010-input-access-methods.md) | Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick) | draft | apple, windows, gtk, android, core |


### PR DESCRIPTION
## What

Adds Android to the platform matrices of the existing RFCs, drafts three new RFCs, and improves the contribution docs.

## Changes

**Platform-matrix amendments** — Android added to:
- 0001 (analytics), 0002 (Lucide icons), 0003 (multilingual UI), 0004 (onboarding), 0006 (settings IA), and the \fcs/README.md\ index.
- 0005 (v5 migration) intentionally left as-is — there is no Dasher v5 Android predecessor.

**New RFCs**
- **0008 — Keyboard extension / IME onboarding (Apple + Android).** The shared state model (\
otEnabled\ / \nabledNotDefault\ / \
eedsPermission\ / \eady\), per-platform detection + deep-links, first-run prompt + resume-on-return. Complements RFC 0004, which deliberately excluded the keyboard-enablement step.
- **0009 — Crash reporting & engine diagnostics capture.** The crash envelope (exception type, scrubbed stack, \ngine_log_tail\), per-platform hooks, and the ring-buffer bridge for DasherCore's \dasher_set_log_callback\. Extends RFC 0001.
- **0010 — Input & access methods (DRAFT).** Frames the steering × selection matrix, switch profile, dwell, eye-gaze tracker abstraction (proposes adopting Windows's UDP gaze protocol cross-platform). Status \draft\ — not ready for consensus; unresolved questions are the focus.

**Process / docs**
- Added a \draft\ status to the template + README status table.
- New focused **CONTRIBUTING.md** (DCO, RFC workflow, how to add a platform, repo map).
- README: fixed a couple of typos and added Dasher-Android to the active-codebases list.

## Notes
- All RFCs retain \status: proposed\ (or \draft\ for 0010) — no decisions are being pre-empted.
- DCO: commit is \Signed-off-by\.
