### PR TITLE
docs: fix contradictory icon-count claim in RFC 0002

### DIFF
--- a/rfcs/0002-lucide-icons.md
+++ b/rfcs/0002-lucide-icons.md
@@ -172,7 +172,7 @@ Apple's native icon set. Excellent on Apple platforms, but:
 ### Tabler Icons
 
 - Similar to Lucide (open source, stroke-based, MIT licence).
-- Fewer icons (~4,000 vs Lucide's 1,400+, though both are large).
+- More icons (~4,000 vs Lucide's 1,400+, though both are large).
 - Less adoption / smaller community.
 - No ready-made Avalonia package.
 


### PR DESCRIPTION
RFC 0002 labelled Tabler Icons as having 'Fewer icons' while stating ~4,000 vs Lucide's 1,400+. Corrected the label to match the numbers in the same line. Documentation-only.