### PR TITLE
rfcs: status & implementation audit across all frontends (0001-0014)

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -13,6 +13,15 @@ updated: YYYY-MM-DD
 
 One paragraph explaining the change. What does it do, and at a high level, how?
 
+## Implementation status
+
+Once the RFC starts to land, record the real state here, platform by platform.
+Use a short table (Platform | State | Notes) and plain facts: "implemented",
+"partial", or "not started". State the date of the audit. This section is the
+single place a reader looks for "is it built, and where" — keep it honest and
+keep it current. Leave it as "Not yet implemented" until there is something to
+report.
+
 ## Motivation
 
 What problem does this solve? Who feels the pain? Link any issues, user

--- a/rfcs/0001-analytics.md
+++ b/rfcs/0001-analytics.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0001
 title: Privacy-preserving analytics and crash reporting
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android]
 created: 2026-06-17
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Privacy-preserving analytics and crash reporting
@@ -18,6 +18,24 @@ which input methods and languages — and to get visibility into crashes —
 without ever collecting what users type. Collection is strictly opt-in via
 a first-run prompt, the event schema is published openly in the repo, and
 no personally identifiable information is sent.
+
+## Implementation status
+
+Audited August 2026. Implemented on Apple and Windows; not started on GTK,
+Android, or web.
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Apple (iOS, macOS) | Implemented | PostHog SDK wired in; opt-in prompt; seven-event schema; Settings toggle and reset-ID control. |
+| Dasher-Apple (visionOS) | Partial | The SDK is linked, but the opt-in prompt is not shown, so reports do not leave the device until the user opts in elsewhere. |
+| Dasher-Windows | Implemented | PostHog SDK; opt-in dialog; published schema. |
+| Dasher-GTK | Not started | No analytics code. |
+| Dasher-Mobile (Android) | Not started | No analytics code. |
+| dasher-web | Not started | No analytics code. |
+
+The self-hosted PostHog instance and the open event schema are the agreed
+direction. One event in the schema (`input_method_changed`) is not emitted on
+any platform yet.
 
 ## Motivation
 

--- a/rfcs/0002-lucide-icons.md
+++ b/rfcs/0002-lucide-icons.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0002
 title: Adopt Lucide as the cross-platform icon set
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android]
 created: 2026-06-17
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Adopt Lucide as the cross-platform icon set
@@ -16,6 +16,22 @@ ISC-licensed, community-maintained icon library of 1,400+ icons — as the singl
 source of UI iconography across Apple, Windows, and GTK. Each platform uses the
 appropriate Lucide package: `lucide-icons-swift` (Apple SPM),
 `Lucide.Avalonia` (Windows NuGet), and the Lucide TTF font (GTK/Pango).
+
+## Implementation status
+
+Audited August 2026. Implemented on Apple and Windows; not started on GTK,
+Android, or web.
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Apple | Implemented | `lucide-icons-swift`; used in more than 100 places across iOS, macOS, and visionOS. |
+| Dasher-Windows | Implemented | `Lucide.Avalonia`; used in the main window and the settings tabs. |
+| Dasher-GTK | Not started | Uses default gtkmm widgets and text labels. |
+| Dasher-Mobile (Android) | Not started | Uses Google Material symbols, not Lucide. |
+| dasher-web | Not started | Buttons are plain text or Unicode glyphs. |
+
+Lucide is the agreed icon set for Apple and Windows. GTK, Android, and web have
+not adopted it.
 
 ## Motivation
 

--- a/rfcs/0003-multilingual-ui.md
+++ b/rfcs/0003-multilingual-ui.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0003
 title: Multilingual UI support across all frontends
-status: proposed
+status: active
 platforms: [apple, windows, gtk, android, core]
 created: 2026-06-17
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Multilingual UI support across all frontends
@@ -18,6 +18,28 @@ is **hardcoded English** with no native localization wired up. This RFC
 proposes a per-platform localization strategy for frontend strings so that
 users get a fully localised experience — engine *and* UI — and aligns the
 language picker so all 33 DasherCore locales are exposed everywhere.
+
+## Implementation status
+
+Audited August 2026. The engine layer is done. The frontend layer is not done
+on any platform.
+
+DasherCore ships 33 locale files, and every frontend that uses the C API can
+localise parameter labels through `dasher_set_locale`. But the app chrome — the
+toolbar, the settings tabs, the dialogs, the onboarding text — is hardcoded
+English on every frontend. No frontend ships `.xcstrings`, `.resx`, `.po`, or
+`Localizable.strings` files for its own strings.
+
+| Platform | Engine strings | App chrome |
+| --- | --- | --- |
+| Dasher-Apple | Localised (9 locales in the picker) | English only |
+| Dasher-Windows | Localised (10 locales in the picker) | English only |
+| Dasher-GTK | Not bound (the gettext domain is never set) | English only |
+| Dasher-Mobile (Android) | Partial | English only; one `values/` bucket, no translations ship |
+
+The next step is to wrap frontend strings in each platform's native catalog and
+bind the locale list to `locales.json`. The RTL work (Arabic, Persian, Urdu) has
+not started.
 
 ## Motivation
 

--- a/rfcs/0004-onboarding.md
+++ b/rfcs/0004-onboarding.md
@@ -4,7 +4,7 @@ title: First-run onboarding experience
 status: proposed
 platforms: [apple, windows, gtk, android, core]
 created: 2026-06-17
-updated: 2026-06-29
+updated: 2026-08-01
 ---
 
 # First-run onboarding experience
@@ -22,6 +22,21 @@ from DasherCore** (commit `f79eb6a9`, Jun 2026; it had been disabled since 2007
 due to segfaults and was never re-enabled). This RFC frames the onboarding
 problem, documents what exists, identifies the design questions that need
 **UX expert input**, and proposes a phased implementation plan.
+
+## Implementation status
+
+Audited August 2026. Not implemented.
+
+No frontend ships a first-run onboarding flow. The only first-launch prompts
+today are the analytics opt-in (Apple, Windows) and the v5 migration prompt
+(Apple macOS, Windows). visionOS shows a one-time "pinch and look" gesture hint;
+that is a single gesture tip, not an onboarding flow.
+
+Game Mode exists on all platforms and is the closest thing to guided practice,
+but the user invokes it at any time. It is never triggered on first launch.
+
+This RFC still needs UX research before it can move out of `proposed` (see
+"Design questions needing UX expert input").
 
 ## Motivation
 

--- a/rfcs/0005-v5-migration.md
+++ b/rfcs/0005-v5-migration.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0005
 title: "Dasher v5 → v6 migration: settings, alphabets, and user data"
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk]
 created: 2026-06-18
-updated: 2026-06-18
+updated: 2026-08-01
 ---
 
 # Dasher v5 → v6 migration: settings, alphabets, and user data
@@ -19,6 +19,20 @@ frontend detects v5 data in its platform-specific location, translates
 the v5 parameter names to v6 equivalents, copies user-authored XML and
 training files, and presents a brief "Your settings have been imported"
 confirmation. The migration runs exactly once per user account.
+
+## Implementation status
+
+Audited August 2026.
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Apple (macOS) | Implemented | `V5MigrationService` reads the v5 plist and user data; first-launch prompt and a Settings re-import panel. macOS only, by design: v5 had no iOS or visionOS predecessor. |
+| Dasher-Windows | Implemented | `V5MigrationService` reads `%APPDATA%\dasher.rc\settings.xml`; first-launch prompt and a Settings panel. |
+| Dasher-GTK | Not started | No migration code. The XML format matches Windows, so the logic can be shared once the paths are confirmed. |
+
+The parameter mapping (more than 100 parameters), the font-size transform, the
+start-mode consolidation, and the custom-XML copy all run on the two platforms
+that had a v5 predecessor.
 
 ## Motivation
 

--- a/rfcs/0006-settings-ia.md
+++ b/rfcs/0006-settings-ia.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0006
 title: Settings information architecture and progressive disclosure
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android, core]
 created: 2026-06-18
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Settings information architecture and progressive disclosure
@@ -23,6 +23,24 @@ progressive-disclosure mechanism: **Simple** (common only), **Advanced**
 (+ advanced), **Pro** (all), with a user-facing toggle and sensible defaults.
 It also addresses tab structure consistency, contextual filtering refinement,
 and the critical need for end-user research to validate the tier assignments.
+
+## Implementation status
+
+Audited August 2026. The tab structure and the dynamic rendering from the engine
+manifest are implemented on most platforms. The three-tier progressive disclosure
+(Simple / Advanced / Pro) is not implemented on any platform.
+
+| Platform | Tabs from manifest | Tier filtering |
+| --- | --- | --- |
+| Dasher-Apple (iOS, macOS) | Yes (7 tabs) | No |
+| Dasher-Windows | Yes (10 tabs) | No |
+| Dasher-GTK | Yes (dynamic, from the parameter schema) | No |
+| dasher-web | Own panel structure (8 panels) | No |
+| Dasher-Mobile (Android) | No (a flat 5-row list, not from the manifest) | No |
+
+The `tier` field exists in `settings_manifest.json`, but the C API collapses it
+to a binary `advanced` flag, and no frontend filters by it. The end-user
+card-sort study to validate the tier assignments has not run.
 
 ## Motivation
 

--- a/rfcs/0007-dark-mode-palettes.md
+++ b/rfcs/0007-dark-mode-palettes.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0007
 title: Dark mode support via appearance-aware colour palettes
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android, web, core]
 created: 2026-06-19
-updated: 2026-06-19
+updated: 2026-08-01
 ---
 
 # Dark mode support via appearance-aware colour palettes
@@ -20,6 +20,20 @@ between light and dark. No new rendering path is introduced: dark
 palettes are ordinary palettes that inherit a light palette via the
 existing `parentName` mechanism and override only the UI chrome
 colours (background, labels, outlines, info/warning boxes).
+
+## Implementation status
+
+Audited August 2026. The engine layer is done. DasherCore exposes the appearance
+mode, the system-appearance input, the dual palette preferences, and the
+companion lookup. Eight dark companion palettes ship.
+
+| Platform | Canvas (engine palettes) | App chrome |
+| --- | --- | --- |
+| Dasher-Apple | Implemented (System / Light / Dark; separate light and dark pickers) | Implemented (asset-catalog dark variants) |
+| Dasher-Windows | Implemented | Implemented (theme dictionaries) |
+| Dasher-GTK | Partial (the palette chooser follows the engine) | Not implemented (the window chrome does not follow the OS) |
+| Dasher-Mobile (Android) | Partial | Partial (the system chrome follows; the custom UI hardcodes light colours) |
+| dasher-web | Not started | Not started |
 
 ## Motivation
 

--- a/rfcs/0008-keyboard-onboarding.md
+++ b/rfcs/0008-keyboard-onboarding.md
@@ -4,7 +4,7 @@ title: Keyboard extension / IME onboarding (Apple & Android)
 status: proposed
 platforms: [apple, android, core]
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Keyboard extension / IME onboarding (Apple & Android)
@@ -25,6 +25,19 @@ detects the keyboard's enablement state and walks the user through enabling it,
 with deep-links into the exact system screens. It complements the generic
 first-run onboarding in [RFC 0004](./0004-onboarding.md), which deliberately did
 not cover the keyboard-enablement step.
+
+## Implementation status
+
+Audited August 2026. Not implemented.
+
+- Dasher-Apple ships the iOS keyboard extension, but the host app has no
+  enablement guide, no Full Access check, and no deep link into the system
+  settings. The host app never mentions the keyboard.
+- Dasher-Mobile ships the Android IME (`InputMethodService`), but there is no
+  in-app flow to guide the user to enable or select it.
+
+The shared state model and the deep-link flow described in this RFC have not been
+built on either platform.
 
 ## Motivation
 

--- a/rfcs/0009-crash-reporting.md
+++ b/rfcs/0009-crash-reporting.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0009
 title: Crash reporting & engine diagnostics capture
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android, core]
 created: 2026-06-28
-updated: 2026-06-29
+updated: 2026-08-01
 ---
 
 # Crash reporting & engine diagnostics capture
@@ -21,6 +21,20 @@ time — never from the crashing process itself.
 This extends RFC 0001, which left crash detail open. Reference implementation:
 **Dasher-Windows**; macOS implemented; iOS/visionOS (production), GTK, and
 Android pending.
+
+## Implementation status
+
+Audited August 2026. The engine layer is done. DasherCore catches exceptions at
+the C-API boundary, routes them through the log callback, and exposes
+`dasher_has_engine_error`.
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Windows | Implemented | Reference implementation: `AppDomain.UnhandledException`, crash file, PII scrubber with tests. |
+| Dasher-Apple (macOS) | Implemented | `NSSetUncaughtExceptionHandler` plus an alive-marker unclean-shutdown detector. PostHog is the sole channel (macOS has no TestFlight). |
+| Dasher-Apple (iOS, visionOS) | Not started in production | Betas lean on TestFlight. The PostHog `$exception` path for production builds is pending. Caught engine errors are reported through `captureEngineError` on all Apple targets. |
+| Dasher-GTK | Not started | No signal handler or crash file. |
+| Dasher-Mobile (Android) | Not started | No `UncaughtExceptionHandler`; no native signal shim. |
 
 ## The contract
 

--- a/rfcs/0010-input-access-methods.md
+++ b/rfcs/0010-input-access-methods.md
@@ -1,19 +1,20 @@
 ---
 rfc: 0010
 title: Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick)
-status: draft
+status: active
 platforms: [apple, windows, gtk, android, core]
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick)
 
-> **This RFC is a DRAFT.** It exists to frame a large, under-specified area that
-> is implemented ad-hoc and inconsistently across the v6 frontends. It is **not**
-> ready for consensus; the Unresolved Questions section is the most important
-> part. The intent is to align maintainers on the shape of the problem before any
-> platform invests in deeper work.
+> **Status (August 2026):** the canonical model below is agreed — the nine
+> selection methods, the seven steering methods, and the compatibility matrix.
+> Apple and Windows were verified to match for the methods they share, so this
+> RFC is now `active`. What remains open is the switch-access design (consume the
+> OS Switch Access / Switch Control vs. in-app capture) and the eye-gaze tracker
+> abstraction; see "Proposals still open".
 
 ## Summary
 
@@ -28,6 +29,23 @@ dwell / 1-switch / 2-switch / 2-push / scanning / direct-boxes) — is a
 different data model, and different gaps. This RFC proposes a shared
 **access-method model** and a per-platform integration spec so that "set up your
 access method" means the same thing on Apple, Windows, GTK, and Android.
+
+## Implementation status
+
+Audited August 2026. Promoted from `draft` to `active`: the canonical model
+below is now agreed. The Apple and Windows compatibility matrices were verified
+identical for the steering methods both platforms share.
+
+| Platform | Steering methods available | Notable gaps |
+| --- | --- | --- |
+| Dasher-Apple | pointer, touch, eye gaze (hover), tilt, switches, hand tracking (visionOS) | Joystick is listed but has no `GCController` capture. iOS switch capture is partial. |
+| Dasher-Windows | pointer, touch, eye gaze (WinRT + UDP), joystick | No switch-capture UI. No dwell rendering. |
+| Dasher-GTK | pointer, joystick (SDL), switch (keyboard) | No eye-gaze path of its own. |
+| Dasher-Mobile (Android) | touch, tilt | No switch, dwell, or eye gaze. |
+| dasher-web | pointer, touch, keyboard | No eye gaze, joystick, switch, or dwell. |
+
+The canonical lists and the compatibility matrix are agreed. The eye-gaze
+tracker abstraction and the switch-access design remain open.
 
 ## Motivation
 
@@ -51,7 +69,67 @@ access method" means the same thing on Apple, Windows, GTK, and Android.
   Windows WinRT+UDP / nothing on Android) with no shared tracker abstraction or
   wire protocol.
 
-## Detailed design (shape — to be refined)
+## Canonical model (agreed August 2026)
+
+The lists and the matrix below are **normative**: every frontend must use these
+names and must match this matrix. They were verified identical across Apple
+(`DasherShared/SelectionMethod.swift`, `AccessMethod.swift`) and Windows
+(`Engine/SelectionMethod.cs`, `AccessMethod.cs`) for the steering methods both
+platforms share.
+
+### Selection methods — the engine contract
+
+There are nine selection methods. Each maps 1:1 to an `SP_INPUT_FILTER` value in
+DasherCore, so the engine is the source of truth for this side. The mapping
+below must live in `DasherCore/docs` (next to `C_API.md`) so every frontend
+reads one table, not two. (Follow-up task for the DasherCore repo.)
+
+| Selection method | `SP_INPUT_FILTER` | Switch-based | Switches |
+| --- | --- | --- | --- |
+| continuous | `Normal Control` | no | 0 |
+| pressToMove | `Press Mode` | no | 0 |
+| clickToZoom | `Click Mode` | no | 0 |
+| dwell | `Normal Control` | no | 0 |
+| oneSwitch | `One Button Dynamic Mode` | yes | 1 |
+| twoSwitches | `Two Button Dynamic Mode` | yes | 2 |
+| twoPush | `Two Push Dynamic Mode` | yes | 1 |
+| scanning | `Menu Mode` | yes | 1 |
+| directBoxes | `Direct Mode` | yes | 1 |
+
+### Steering methods — per-platform, hardware-gated
+
+Steering methods are not a shared enum. They differ by hardware, and that is
+correct. The names are shared; availability is not.
+
+| Steering method | Apple | Windows | GTK | Android | Web |
+| --- | --- | --- | --- | --- | --- |
+| pointer | yes | yes | yes | yes | yes |
+| touch | yes | yes | yes | yes | yes |
+| eyeGaze | yes | yes | — | — | — |
+| tilt | iOS only | — | — | yes | — |
+| joystick | listed (no capture yet) | yes | yes (SDL) | — | — |
+| handTracking | visionOS only | — | — | — | — |
+| switchesOnly | yes | yes | yes | — | — |
+
+### Compatibility matrix — normative
+
+A frontend must offer only the selection methods marked for the active steering
+method. Apple and Windows already match this matrix for the methods they share.
+
+| Steering \ Selection | continuous | pressToMove | clickToZoom | dwell | oneSwitch | twoSwitches | twoPush | scanning | directBoxes |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| pointer | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| touch | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ | ✓ |
+| eyeGaze | ✓ | — | — | ✓ | ✓ | ✓ | — | ✓ | ✓ |
+| tilt | ✓ | ✓ | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
+| joystick | ✓ | ✓ | ✓ | — | ✓ | ✓ | — | ✓ | ✓ |
+| handTracking | ✓ | — | — | ✓ | ✓ | ✓ | — | — | — |
+| switchesOnly | — | — | — | — | ✓ | ✓ | ✓ | ✓ | ✓ |
+
+## Proposals still open (eye-gaze, switch profile, dwell)
+
+The canonical model above is agreed. The sections below are proposals for the
+parts that are still open. They are not normative yet.
 
 ### Shared concepts
 
@@ -167,10 +245,13 @@ all four platforms adopt the same shape.
 
 ## Unresolved questions (the most important section)
 
-1. **Canonical method enums.** Can Apple and Windows agree on a single shared
+1. **Canonical method enums.** ~~Can Apple and Windows agree on a single shared
    list of `SteeringMethod` × `SelectionMethod` values (and a compatibility
    matrix)? If yes, does it live in DasherCore as documentation, or only in this
-   RFC?
+   RFC?~~ **Resolved (August 2026):** yes — see the Canonical model. The nine
+   selection methods are agreed, the matrix is agreed, and the selection →
+   `SP_INPUT_FILTER` mapping will live in `DasherCore/docs` as the SSOT.
+   Steering methods stay per-platform (hardware-gated), names shared.
 2. **Switch Access vs. in-app switch capture on mobile.** On Android and iOS,
    should Dasher consume the **system** switch-access/switch-control events
    (lower friction, honours the user's existing switch setup) or capture its own
@@ -193,9 +274,20 @@ all four platforms adopt the same shape.
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
+- Status: _accepted (canonical model agreed; switch-access design still open)_
+- Decided by: _maintainers_
+- Date: _2026-08-01_
+- Decision: _The nine selection methods, the seven steering methods, and the
+  compatibility matrix are normative. The selection → `SP_INPUT_FILTER` mapping
+  is engine-owned and moves to `DasherCore/docs`. Steering methods stay
+  per-platform. The switch-access question (Q2) stays open and blocks deeper
+  switch work, not the model itself._
 
-- Status: _draft — not ready for consensus_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+## History
+
+- 2026-06-28 — initial proposal, marked `draft` to frame the problem.
+- 2026-08-01 — promoted to `active`. Verified that Apple and Windows already
+  share identical selection-method lists, identical `SP_INPUT_FILTER` mappings,
+  and identical compatibility matrices for the steering methods they share. Made
+  those the normative Canonical model. Resolved Q1 (the mapping lives in
+  DasherCore). Q2 (switch access) remains open.

--- a/rfcs/0011-testing.md
+++ b/rfcs/0011-testing.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0011
 title: Testing expectations for RFCs
-status: proposed
+status: active
 platforms: [apple, windows, gtk, android, web, core]
 created: 2026-06-28
-updated: 2026-06-28
+updated: 2026-08-01
 ---
 
 # Testing expectations for RFCs
@@ -21,6 +21,20 @@ RFC on one frontend knows both what to write and where to put it.
 This is guidance, **not a merge gate**: a missing or thin test plan does not
 block an RFC from going `active`. Reviewers are expected to ask about it; the
 author is expected to answer.
+
+## Implementation status
+
+Audited August 2026. Adopted in practice. The `Testing` section is in the
+template, and the README cross-references this RFC. It is guidance, not a gate.
+
+| Repo | Framework | State |
+| --- | --- | --- |
+| DasherCore | doctest (C++) | Mature; about 38 test files; the strongest layer. |
+| Dasher-Windows | xUnit | Active (for example, `PiiScrubberTests`). |
+| Dasher-Apple | XCTest | Files exist, but `project.yml` declares `testTargets: []`; the tests are not wired into a build target. |
+| Dasher-Mobile (Android) | JUnit 4 / AndroidX | Deps are in the version catalog; no test sources yet. |
+| dasher-web | None | No test runner is wired up. |
+| Dasher-GTK | doctest | Minimal (one dwell-click test). |
 
 ## Motivation
 

--- a/rfcs/0012-typing-rate.md
+++ b/rfcs/0012-typing-rate.md
@@ -1,10 +1,10 @@
 ---
 rfc: 0012
 title: Typing rate (CPS / WPM) display
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android, core]
 created: 2026-07-18
-updated: 2026-07-18
+updated: 2026-08-01
 ---
 
 # Typing rate (CPS / WPM) display
@@ -16,6 +16,19 @@ minute (WPM)** — live, over a short rolling window so it is responsive but
 stable. Always visible in **game mode**; **opt-in** during regular use via a
 Settings toggle. Computed **engine-side** (DasherCore) and exposed through the
 C API so every frontend displays the same number.
+
+## Implementation status
+
+Audited August 2026. The engine layer is done. DasherCore exposes
+`dasher_get_wpm` and `dasher_get_cps` (WPM = CPS × 12).
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Apple (iOS, macOS) | Implemented | Live WPM, max, and average in the canvas overlay and in game mode; a Settings toggle (`showTypingRate`). CPS is not shown; only WPM. |
+| dasher-web | Implemented | Own JS engine; live WPM, peak WPM, and accuracy. Does not consume the DasherCore C API. |
+| Dasher-Windows | Not started | No WPM or CPS display. |
+| Dasher-GTK | Not started | The bundled DasherCore predates `dasher_get_wpm`. |
+| Dasher-Mobile (Android) | Not started | The bundled DasherCore fork predates this feature. |
 
 ## Motivation
 

--- a/rfcs/0013-custom-rendering.md
+++ b/rfcs/0013-custom-rendering.md
@@ -1,37 +1,74 @@
 ---
 rfc: 0013
-title: Custom rendering API (two-strand)
-status: proposed
+title: Node-tree rendering API (custom rendering)
+status: active
 platforms: [apple, windows, gtk, android, web, core]
 created: 2026-07-25
-updated: 2026-07-25
+updated: 2026-08-01
 ---
 
-# Custom rendering API (two-strand)
+# Node-tree rendering API (custom rendering)
 
 ## Summary
 
-Give frontends a choice: render Dasher from the existing flat draw-command
-buffer (the current path), **or** query the live node tree and render it
-themselves with their own graphics API. The two strands coexist — a frontend
-can use the command buffer for most things and drop into custom rendering for
-specific features (3D cubes, VR spatial layouts, custom visualisations), or
-render everything from scratch.
+Give a frontend a second way to render Dasher. Today every frontend renders from
+the flat draw-command buffer. This RFC adds a second path: the frontend queries
+the live node tree and draws it with its own graphics API. The two paths
+coexist. A frontend can use the command buffer for most of its drawing and drop
+into node-tree rendering for a specific feature, or it can render everything from
+scratch.
+
+> **Naming note (August 2026).** This RFC used to call the two paths "Strand 1"
+> and "Strand 2". Those names said nothing about what each path does. They are
+> renamed here:
+>
+> - **command-buffer rendering** — the existing path (`dasher_frame` returns an
+>   `int[]` of draw commands; the frontend replays them).
+> - **node-tree rendering** — the path this RFC adds (`dasher_get_visible_nodes`
+>   returns the node tree; the frontend draws it itself).
+
+## Implementation status
+
+Audited August 2026. The engine API is implemented and tested. No production
+frontend uses it.
+
+- **DasherCore: implemented and tested.** `dasher_get_visible_nodes`,
+  `dasher_set_visible_nodes_enabled`, `dasher_get_viewport`, and the
+  `dasher_node_info` / `dasher_viewport` structs all exist in `dasher.h` and
+  `CAPI.cpp`, with tests in `tests/test_strand2_nodes.cpp` and
+  `tests/test_node_tree.cpp`.
+- **Frontends: none use it in production.** Every Apple target, plus Windows,
+  GTK, Android, and web, renders through the command buffer
+  (`dasher_frame` → `int[]`). None calls `dasher_get_visible_nodes`.
+- **DasherMac (experimental).** A branch of the macOS app uses node-tree
+  rendering to draw the cube (3D) shape mode. The work is experimental and
+  buggy. It is not merged and does not ship.
+- **Scope.** There is no plan to bring node-tree rendering to every platform.
+  It exists for the frontends that need full visual control (3D, VR, custom
+  accessibility views). The command buffer stays the default.
+
+### Where this might still matter
+
+The most promising future use is a spatial, eye-tracked port — for example a
+Meta Quest build that renders the node tree in 3D and drives it with foveated
+eye tracking. That is future work, not a near-term plan. The API is in place so
+that such a port can read the node tree through the same C boundary as every
+other frontend.
 
 ## Motivation
 
-The flat `int[]` command buffer (`dasher_frame`) is 2D painter's algorithm —
-no depth buffer, no perspective, no compositing. It works well for flat
+The flat `int[]` command buffer (`dasher_frame`) is a 2D painter's algorithm. It
+has no depth buffer, no perspective, and no compositing. It works well for flat
 rectangles, circles, text, and lines. It **cannot** represent:
 
-- **3D extruded cubes** (LP_SHAPE_TYPE = CUBE). The depth data
-  (`CubeDepthLevel`) exists inside DasherCore but is discarded when serialised
-  to the flat buffer. A two-pass frontend overlay (buffering opcode-7 cubes,
-  rendering shaded faces on top) was prototyped but produces a barely-visible
-  effect because the flat buffer's painter's algorithm buries parent shading
-  under child rectangles.
-- **Spatial / VR rendering** (visionOS). Placing Dasher nodes in 3D space,
-  with depth based on zoom level, is impossible through the flat buffer.
+- **3D extruded cubes** (`LP_SHAPE_TYPE = CUBE`). The depth data
+  (`CubeDepthLevel`) exists inside DasherCore, but the flat buffer discards it
+  when it serialises the commands. A two-pass frontend overlay (buffer the
+  opcode-7 cubes, then draw the shaded faces on top) was prototyped. The effect
+  is barely visible, because the painter's algorithm buries the parent shading
+  under the child rectangles.
+- **Spatial or VR rendering** (visionOS). Placing Dasher nodes in 3D space, with
+  depth based on the zoom level, is impossible through the flat buffer.
 - **Alternative visualisations** — radial trees, force-directed layouts,
   particle effects, animated transitions.
 - **Custom accessibility rendering** — high-contrast simplified views,
@@ -39,7 +76,7 @@ rectangles, circles, text, and lines. It **cannot** represent:
 
 ### What already exists
 
-DasherCore already has "test/diagnostic hooks" (`dasher.h` §Test, marked "NOT
+DasherCore already has test and diagnostic hooks (`dasher.h`, §Test, marked "not
 intended for production frontends") that expose raw node-tree data:
 
 ```c
@@ -51,32 +88,32 @@ int dasher_screen_to_dasher(ctx, sx, sy, &dx, &dy);
 int dasher_get_alphabet_symbol_text(ctx, index, buf, len);
 ```
 
-These prove the concept — a frontend can query node positions and text. They
-just aren't complete enough for full rendering (no recursive tree walking, no
-node colours, no labels for group/control nodes).
+These prove the concept: a frontend can query node positions and text. They are
+not complete enough for full rendering (no recursive tree walk, no node colours,
+no labels for group or control nodes).
 
 ## Detailed design
 
-### Two strands, coexisting
+### Two paths, coexisting
 
 ```
-Strand 1 (existing, default):
-  dasher_frame() → int[] draw commands → frontend renders
+Command-buffer rendering (existing, default):
+  dasher_frame() -> int[] draw commands -> the frontend renders
 
-Strand 2 (new, opt-in):
-  dasher_get_visible_nodes() → node tree data → frontend renders from scratch
+Node-tree rendering (new, opt-in):
+  dasher_get_visible_nodes() -> node tree data -> the frontend renders from scratch
 ```
 
-A frontend uses whichever strand it wants. Most frontends use Strand 1 (simpler,
-less code). A frontend that needs 3D, VR, or custom visuals uses Strand 2 for
-some or all of its rendering.
+A frontend uses whichever path it wants. Most frontends use the command buffer,
+because it is simpler and needs less code. A frontend that needs 3D, VR, or
+custom visuals uses node-tree rendering for some or all of its drawing.
 
-### Strand 2 API: node tree exposure
+### The node-tree API
 
-Both structs begin with a `struct_size` field (set by the caller to
-`sizeof(dasher_node_info)` / `sizeof(dasher_viewport)` before the call) so the
-engine can detect the ABI version and gracefully ignore fields it doesn't know
-about. This lets the structs evolve without new symbols or breaking existing
+Both structs begin with a `struct_size` field. The caller sets this to
+`sizeof(dasher_node_info)` or `sizeof(dasher_viewport)` before the call. The
+engine then detects the ABI version and ignores fields it does not know. This
+lets the structs evolve without new symbols and without breaking existing
 frontends.
 
 ```c
@@ -89,8 +126,8 @@ typedef struct dasher_node_info {
     int       has_children;     // 1 if this node has visible children
     int       depth;            // Recursion depth from root (0 = root child)
     int       is_game_node;     // 1 if on the game-mode path
-    // Screen-space bounds (pre-computed by the engine — saves the frontend
-    // from calling dasher_dasher_to_screen for every node).
+    // Screen-space bounds (the engine pre-computes these, so the frontend does
+    // not call dasher_dasher_to_screen for every node).
     int screen_x1, screen_y1, screen_x2, screen_y2;
     // Colours (from the active palette).
     int fill_argb;
@@ -100,20 +137,19 @@ typedef struct dasher_node_info {
 } dasher_node_info;
 
 // Query the visible node tree. Returns the number of nodes written (up to
-// max_nodes). The result is clipped to the visible region — exactly the same
-// set of nodes the command buffer would render for the same frame — so Strand 1
-// and Strand 2 see identical node sets and the parity invariant holds.
+// max_nodes). The result is clipped to the visible region — the same set of
+// nodes the command buffer would render for the same frame — so the two paths
+// see the same nodes and the parity invariant holds.
 //
-// Nodes are returned in depth-first tree-traversal order (parent before
-// children). This is convenient for painter's-algorithm frontends (render in
-// the returned order), but a 3D frontend will typically re-sort back-to-front
-// or use a z-buffer, so the ordering should be treated as tree-traversal
-// order, not a mandated render order.
+// Nodes come back in depth-first tree-traversal order (parent before children).
+// This is convenient for a painter's-algorithm frontend (draw in the returned
+// order). A 3D frontend will usually re-sort back-to-front or use a z-buffer,
+// so treat the order as tree-traversal order, not a required draw order.
 //
-// out_strings holds label text for nodes that have one; label_index in
+// out_strings holds the label text for nodes that have one; label_index in
 // dasher_node_info indexes into it. Both out_nodes and out_strings point into
-// engine-owned buffers valid until the next call to dasher_frame or
-// dasher_get_visible_nodes on this context — copy if you need the data beyond
+// engine-owned buffers that stay valid until the next call to dasher_frame or
+// dasher_get_visible_nodes on this context. Copy the data if you need it beyond
 // the next frame.
 DASHER_API int dasher_get_visible_nodes(
     dasher_ctx* ctx,
@@ -135,157 +171,157 @@ typedef struct dasher_viewport {
 DASHER_API int dasher_get_viewport(dasher_ctx* ctx, dasher_viewport* out);
 ```
 
-### How a frontend uses Strand 2
+### How a frontend uses node-tree rendering
 
-```
-1. dasher_mouse_move / dasher_frame as normal (engine advances)
-2. dasher_get_visible_nodes → array of dasher_node_info + strings
-3. For each node (in returned order, or re-sort for 3D):
-   - Render it however you want (flat rect, 3D cube, sphere, text card)
-   - Use fill_argb / outline_argb for colours
-   - Use label_index → out_strings for text
-   - Use screen_x1..y2 for position
-   - Use has_children + depth for tree-aware rendering (e.g. 3D extrusion
-     scaled by depth)
-4. Optionally call dasher_frame too (for the crosshair, game decorations, etc.)
-   and render those commands on top — or render the crosshair yourself from
+1. Call `dasher_mouse_move` / `dasher_frame` as normal so the engine advances.
+2. Call `dasher_get_visible_nodes` to get the array of `dasher_node_info` and
+   the strings.
+3. For each node (in the returned order, or re-sorted for 3D):
+   - Draw it however you want (flat rect, 3D cube, sphere, text card).
+   - Use `fill_argb` / `outline_argb` for the colours.
+   - Use `label_index` → `out_strings` for the text.
+   - Use `screen_x1..y2` for the position.
+   - Use `has_children` and `depth` for tree-aware drawing (for example, 3D
+     extrusion scaled by depth).
+4. Optionally call `dasher_frame` too (for the crosshair, game decorations, and
+   so on) and draw those commands on top. Or draw the crosshair yourself from
    the viewport data.
-```
 
 ### What the engine provides vs what the frontend decides
 
-| Concern | Engine (Strand 2) | Frontend |
-|---|---|---|
-| Node positions (Dasher + screen) | ✅ via `dasher_node_info` | — |
-| Node colours | ✅ from active palette | may override |
-| Node text labels | ✅ via strings array | may restyle |
-| Node tree structure | ✅ depth-first order, depth, has_children | — |
-| Shape (rect / circle / cube / triangle) | ❌ not the engine's call | ✅ frontend decides |
-| Depth / 3D extrusion | ❌ | ✅ frontend decides (e.g. from `depth`) |
-| Animation / transitions | ❌ | ✅ frontend decides |
-| Input handling | ✅ mouse_move / key_event | — |
-| Language model / probabilities | ✅ | — |
+| Concern | Engine (node-tree) | Frontend |
+| --- | --- | --- |
+| Node positions (Dasher and screen) | Yes, via `dasher_node_info` | — |
+| Node colours | Yes, from the active palette | May override |
+| Node text labels | Yes, via the strings array | May restyle |
+| Node tree structure | Yes (depth-first order, depth, has_children) | — |
+| Shape (rect / circle / cube / triangle) | Not the engine's call | The frontend decides |
+| Depth / 3D extrusion | Not provided | The frontend decides (for example, from `depth`) |
+| Animation / transitions | Not provided | The frontend decides |
+| Input handling | Yes (`mouse_move` / `key_event`) | — |
+| Language model / probabilities | Yes | — |
 
-The key shift: **shape and depth become frontend concerns, not engine
-concerns.** LP_SHAPE_TYPE becomes a hint, not a mandate — the frontend can
-render cubes, flat rects, or something entirely new. A frontend that wants 3D
-cube extrusion derives it from `dasher_node_info.depth` — no separate
-extrusion level is needed in the viewport.
+The key shift: **shape and depth become frontend concerns, not engine concerns.**
+`LP_SHAPE_TYPE` becomes a hint, not a mandate. The frontend can draw cubes, flat
+rectangles, or something new. A frontend that wants 3D cube extrusion derives it
+from `dasher_node_info.depth`; the viewport does not need a separate extrusion
+level.
 
-### Relationship to Strand 1
+### Relationship to command-buffer rendering
 
-The strands are not mutually exclusive:
+The two paths are not mutually exclusive:
 
-- **Default:** Strand 1 only. `dasher_frame()` → `int[]` → render. Simplest.
-- **Hybrid:** Strand 1 for most rendering + Strand 2 for specific features.
-  Example: use `dasher_frame()` for everything, but when LP_SHAPE_TYPE is CUBE,
-  switch to `dasher_get_visible_nodes()` and render 3D cubes from the node
-  tree.
-- **Full custom:** Strand 2 only. Frontend renders everything from node data.
-  Most flexible; most work.
+- **Default:** command buffer only. `dasher_frame()` → `int[]` → render. Simplest.
+- **Hybrid:** command buffer for most drawing, plus node-tree rendering for a
+  specific feature. For example, call `dasher_frame()` for everything, but when
+  `LP_SHAPE_TYPE` is `CUBE`, switch to `dasher_get_visible_nodes()` and draw 3D
+  cubes from the node tree.
+- **Full custom:** node-tree only. The frontend renders everything from the node
+  data. Most flexible; most work.
 
-### What about the existing opcode-7 cube experiment?
+### What about the opcode-7 cube experiment?
 
 The opcode-7 approach (DasherCore PR #50) carries cube depth data through the
-flat buffer for a frontend two-pass overlay. It works (cubes are buffered and
-rendered on top) but the effect is underwhelming because the flat buffer's
-painter's algorithm limits the visual result.
+flat buffer for a frontend two-pass overlay. It works — the cubes are buffered
+and drawn on top — but the effect is weak, because the painter's algorithm
+limits the visual result.
 
-With Strand 2, opcode 7 becomes unnecessary — the frontend has the full node
-tree and can render proper 3D cubes directly. The recommendation is:
+With node-tree rendering, opcode 7 is unnecessary: the frontend has the full
+node tree and can draw real 3D cubes directly. The recommendation is:
 
-- **Withdraw opcode 7** from the command buffer (it added complexity for a
-  limited result).
-- **Keep LP_SHAPE_TYPE** as a hint (the frontend can read it via
-  `dasher_get_long_parameter` and use it to choose its rendering style).
-- **Frontends that want cubes** use Strand 2 + their own 3D rendering.
+- **Withdraw opcode 7** from the command buffer (it added complexity for a weak
+  result).
+- **Keep `LP_SHAPE_TYPE`** as a hint (the frontend can read it through
+  `dasher_get_long_parameter` and use it to choose its drawing style).
+- **Frontends that want cubes** use node-tree rendering plus their own 3D code.
 
 ## Drawbacks
 
-- **API surface growth.** `dasher_get_visible_nodes` + `dasher_viewport` +
-  `dasher_node_info` is a significant new API. The `struct_size` ABI-versioning
-  field mitigates forward-compatibility concerns, but the API still needs docs
-  and tests.
-- **Duplication of rendering logic.** Each frontend that uses Strand 2
-  reimplements coordinate transforms, colour lookups, text positioning, etc.
-  that DasherViewSquare already does. This is by design (flexibility) but it's
-  more code per frontend.
+- **API surface growth.** `dasher_get_visible_nodes`, `dasher_viewport`, and
+  `dasher_node_info` are a significant new API. The `struct_size`
+  ABI-versioning field mitigates the forward-compatibility risk, but the API
+  still needs docs and tests.
+- **Duplicate drawing logic.** Each frontend that uses node-tree rendering
+  reimplements the coordinate transforms, the colour lookups, and the text
+  positioning that `DasherViewSquare` already does. This is by design
+  (flexibility), but it is more code per frontend.
 - **Performance.** Copying the node tree into a struct array every frame has a
-  cost. For typical Dasher (50–200 visible nodes) this is negligible; for
-  extreme cases it may matter.
-- **Potential for inconsistency.** A custom-rendering frontend might position
-  nodes slightly differently than the command-buffer path, leading to
-  mismatched input coordinates. The pre-computed `screen_x1..y2` fields
-  mitigate this (the engine does the coordinate transform).
+  cost. For typical Dasher use (50–200 visible nodes) the cost is negligible;
+  for extreme cases it may matter.
+- **Risk of inconsistency.** A custom-rendering frontend might position nodes
+  slightly differently from the command-buffer path, which would mismatch the
+  input coordinates. The pre-computed `screen_x1..y2` fields mitigate this,
+  because the engine does the coordinate transform.
 
 ## Alternatives considered
 
-- **Opcode 7 (cube data in the flat buffer).** Prototyped in DasherCore PR
-  #50. Works but produces an unconvincing 3D effect because the flat buffer's
-  painter's algorithm can't composite depth correctly. Withdraw in favour of
-  Strand 2.
-
-- **New opcodes for every 3D shape.** Rejected: the flat buffer would grow
-  indefinitely (cube, sphere, cylinder, perspective-rect...), and each
-  frontend still has to implement the new opcodes. Strand 2 solves this once.
-
-- **Frontend-specific rendering paths (bypass the C API entirely).** Example:
-  DasherApple queries DasherCore internals directly for node positions.
-  Rejected: violates the C API boundary (CONTRIBUTING Rule 4), not portable,
-  and each frontend reinvents the same queries.
+- **Opcode 7 (cube data in the flat buffer).** Prototyped in DasherCore PR #50.
+  It works, but it produces a weak 3D effect, because the painter's algorithm
+  cannot composite depth. Withdraw it in favour of node-tree rendering.
+- **A new opcode for every 3D shape.** Rejected: the flat buffer would grow
+  without end (cube, sphere, cylinder, perspective-rect, and more), and each
+  frontend would still have to implement the new opcodes. Node-tree rendering
+  solves this once.
+- **Frontend-specific rendering paths (bypass the C API).** For example,
+  Dasher-Apple queries DasherCore internals directly for node positions.
+  Rejected: it breaks the C-API boundary (CONTRIBUTING Rule 4), it is not
+  portable, and each frontend reinvents the same queries.
 
 ## Prior art
 
-- **Browser DOM rendering.** The browser exposes a DOM tree; CSS / JavaScript
-  decide how to render it. Strand 2 is analogous: DasherCore exposes the node
-  tree; the frontend decides how to render it.
-- **Accessibility APIs** (UIAutomation, AXAPI). Expose semantic structure
-  (tree, roles, labels); the consumer (screen reader, automation tool) renders
-  or interprets however it wants.
+- **Browser DOM rendering.** The browser exposes a DOM tree; CSS and JavaScript
+  decide how to render it. Node-tree rendering is analogous: DasherCore exposes
+  the node tree; the frontend decides how to draw it.
+- **Accessibility APIs** (UIAutomation, AXAPI). They expose semantic structure
+  (a tree, roles, labels); the consumer (a screen reader or automation tool)
+  renders or interprets it however it wants.
 - **Unity / Unreal entity-component systems.** The engine provides data; the
-  renderer (which may be swapped) decides visual representation.
+  renderer (which you can swap) decides the visual representation.
 
 ## Testing
 
 Per [RFC 0011](./0011-testing.md):
 
-- **DasherCore unit tests** (`tests/`): verify `dasher_get_visible_nodes`
+- **DasherCore unit tests** (`tests/`): verify that `dasher_get_visible_nodes`
   returns the correct count, tree-traversal order (depth-first), positions
-  (match `dasher_dasher_to_screen`), and colours for a known node tree.
+  (they match `dasher_dasher_to_screen`), and colours for a known node tree.
   Property invariant: the screen bounds in `dasher_node_info` match the
-  opcode-4 rectangles from `dasher_frame` for the same frame (Strand 1/2
-  parity). Verify the node set is clipped to the visible region (same as the
-  command buffer).
-- **Frontend (manual):** render the same node tree in flat mode (Strand 1) and
-  custom mode (Strand 2); verify visual parity. Then switch to cube mode under
-  Strand 2 and verify 3D cubes are visible.
+  opcode-4 rectangles from `dasher_frame` for the same frame (parity between the
+  two paths). Verify that the node set is clipped to the visible region, the
+  same as the command buffer.
+- **Frontend (manual):** draw the same node tree in command-buffer mode and in
+  node-tree mode; verify visual parity. Then switch to cube mode under
+  node-tree rendering and verify that 3D cubes are visible.
 
 ## Unresolved questions
 
-1. **Should the engine still emit opcode 7 (cube data) for frontends that
-   want the two-pass approach?** Or withdraw it entirely in favour of Strand 2?
-   (Recommendation: withdraw.)
+1. **Should the engine still emit opcode 7 (cube data)** for frontends that want
+   the two-pass approach, or withdraw it entirely in favour of node-tree
+   rendering? (Recommendation: withdraw.)
 2. **Colour palette access.** Should the API expose the palette directly
-   (`dasher_get_palette_colors`), or only per-node colours in
+   (`dasher_get_palette_colors`), or only the per-node colours in
    `dasher_node_info`?
 
 ## Resolution
 
-_(Filled in once a decision is reached.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- Status: _accepted (engine API implemented; no production frontend yet)_
+- Decided by: _maintainers_
+- Date: _2026-08-01_
+- Decision: _The C API lands as the second rendering path. It is opt-in and
+  coexists with the command buffer. There is no plan to bring it to every
+  platform; it exists for frontends that need full visual control._
 
 ## History
 
-- 2026-07-25 — initial proposal. Motivated by the cube-mode limitation
-  (DasherCore issue #49, PR #50) and the broader vision of enabling VR/custom
-  rendering through the C API.
-- 2026-07-25 — review feedback incorporated: clipping to visible region
-  (resolved Q2); tree-traversal order documented as traversal, not render
-  order; `struct_size` ABI-versioning field added to both structs; cube depth
-  removed from viewport (frontend derives from `node_info.depth`); string
-  lifetime documented (valid until next `dasher_frame` /
-  `dasher_get_visible_nodes`).
+- 2026-07-25 — initial proposal, framed as a "two-strand" API. Motivated by the
+  cube-mode limit (DasherCore issue #49, PR #50) and the broader goal of VR and
+  custom rendering through the C API.
+- 2026-07-25 — review feedback folded in: clip to the visible region; document
+  tree-traversal order as traversal, not draw order; add the `struct_size`
+  ABI-versioning field; drop cube depth from the viewport (the frontend derives
+  it from `node_info.depth`); document the string lifetime.
+- 2026-08-01 — renamed "Strand 1" / "Strand 2" to **command-buffer rendering**
+  and **node-tree rendering**. Added the honest implementation status: the
+  engine API is implemented and tested, no production frontend uses it, and the
+  DasherMac cube experiment is unmerged and buggy. Recorded that a spatial
+  eye-tracked port (for example Meta Quest) is the most promising future use.

--- a/rfcs/0014-image-labels.md
+++ b/rfcs/0014-image-labels.md
@@ -1,39 +1,77 @@
 ---
 rfc: 0014
 title: Image labels for alphabet symbols
-status: proposed
+status: implemented
 platforms: [apple, windows, gtk, android, web, core]
 created: 2026-07-31
-updated: 2026-07-31
+updated: 2026-08-01
 ---
 
 # Image labels for alphabet symbols
 
 ## Summary
 
-Allow alphabet XML to associate an image path with each symbol. Expose it
-through a single C API function. Frontends query the mapping at startup (or
-when the alphabet changes), cache it, and substitute images for text labels
-during rendering. Works identically for Strand 1 (command buffer) and Strand 2
-(custom rendering). No new opcodes, no Label class changes, no node_info
-changes.
+Allow the alphabet XML to associate an image path with each symbol. Expose the
+path through one C API function. A frontend queries the mapping at startup (or
+when the alphabet changes), caches it, and draws an image instead of the text
+label. The path works the same way for command-buffer rendering and for
+node-tree rendering (see [RFC 0013](./0013-custom-rendering.md)). There are no
+new opcodes, no `Label` class changes, and no `node_info` changes.
+
+## Implementation status
+
+Audited August 2026. The engine API is implemented and tested. Uptake is
+macOS-only and the result is not great.
+
+- **DasherCore: implemented and tested.** The `image=` attribute is parsed in
+  `AlphIO.cpp`; `AlphInfo.h` exposes `GetImage()`; the C API function
+  `dasher_get_alphabet_symbol_image` is in `dasher.h` and `CAPI.cpp`; the test
+  is `tests/test_image_labels.cpp`.
+- **Dasher-Apple (macOS): implemented.** `DasherBridge` builds a label-to-image
+  map, substitutes the image inside the opcode-5 (text) quad, and rebuilds the
+  map when the alphabet changes.
+- **Dasher-Apple (iOS, visionOS, keyboard): not implemented.** These bridges do
+  not call the API.
+- **No bundled alphabet uses it.** No shipped alphabet XML defines an `image=`
+  attribute. The feature is API-ready but unused by the bundled data.
+
+### Honest assessment
+
+Two problems make this less useful than it first looks:
+
+1. **Dynamic image sizing is hard.** Dasher boxes change size every frame as the
+   user zooms. A text label scales cleanly because it is vector geometry. A
+   raster image does not: it scales poorly, it is slow to resize each frame, and
+   the aspect ratio rarely matches the box. The command-buffer path carries no
+   layout hint for images, so the frontend sizes them on its own. On macOS the
+   result works but is not great.
+2. **The driving use case is experimental.** The reason to want image labels is
+   phoneme-based AAC: a pre-literate user needs a picture for each phoneme, not
+   an IPA glyph or an X-SAMPA code. That phoneme work (see
+   `Dasher-Apple/docs/PHONEME_ALPHABET.md` and the `phonemeSymbols/` design
+   assets) is experimental. Until a real phoneme alphabet with real images
+   ships, image labels are infrastructure without a tested consumer.
+
+### Scope
+
+There is no plan to bring image-label rendering to every platform. It landed in
+the engine because the cost is one C API function. The frontend work stays with
+the platforms that have a concrete need (today, macOS).
 
 ## Motivation
 
-Dasher's alphabet XML defines each symbol with a text `label` (what appears
-in the Dasher box) and `text` (what gets output when selected). For
-orthographic alphabets this is sufficient — the label is a letter.
+Dasher's alphabet XML defines each symbol with a text `label` (what appears in
+the Dasher box) and `text` (what is output when the symbol is selected). For an
+orthographic alphabet this is enough — the label is a letter.
 
-For **phoneme-based AAC** (see `feature/phoneme-alphabet-xsampa` branch),
-the label might be an IPA glyph (æ, ʃ) or X-SAMPA code ({, S). These are
-meaningless to pre-literate users — the population that most needs phoneme-
-based AAC. Trinh et al. (2012, 2014) used Jolly Phonics images (42
-pictorial phoneme cards) precisely because their target users were
-non-literate.
+For **phoneme-based AAC**, the label might be an IPA glyph (æ, ʃ) or an X-SAMPA
+code ({, S). These are meaningless to a pre-literate user — the population that
+most needs phoneme-based AAC. Trinh et al. (2012, 2014) used Jolly Phonics images
+(42 pictorial phoneme cards) precisely because their users were non-literate.
 
-The need extends beyond phonemes: any symbol-based AAC alphabet (PCS, Bliss,
-Minspeak) benefits from image labels. Dasher currently has no mechanism to
-render images in boxes — only text.
+The need extends beyond phonemes. Any symbol-based AAC alphabet (PCS, Bliss,
+Minspeak) benefits from image labels. Dasher has no way to draw images in boxes
+today — only text.
 
 ## Detailed design
 
@@ -46,16 +84,17 @@ render images in boxes — only text.
 ```
 
 The `image` attribute is:
-- **Optional.** Nodes without it use the text label (current behaviour).
-- **A relative path** resolved against the alphabet's data directory.
-- **Frontend-resolved.** The engine stores the string; the frontend loads
-  the image file.
+
+- **Optional.** A node without it uses the text label (the current behaviour).
+- **A relative path**, resolved against the alphabet's data directory.
+- **Frontend-resolved.** The engine stores the string; the frontend loads the
+  image file.
 
 ### DasherCore changes
 
-#### 1. AlphInfo: store image path
+#### 1. AlphInfo: store the image path
 
-Add an `Image` field to the `character` struct (`AlphInfo.h:150`):
+Add an `Image` field to the `character` struct (`AlphInfo.h`):
 
 ```cpp
 struct character {
@@ -66,27 +105,27 @@ struct character {
 };
 ```
 
-#### 2. AlphIO: parse image attribute
+#### 2. AlphIO: parse the image attribute
 
-One line in `ReadCharAttributes` (`AlphIO.cpp`, after the existing `Display`
-and `Text` parsing):
+One line in `ReadCharAttributes` (`AlphIO.cpp`, after the existing `Display` and
+`Text` parsing):
 
 ```cpp
 alphabet_character.Image = xml_node.attribute("image").as_string();
 ```
 
-#### 3. CAlphInfo: expose getter
+#### 3. CAlphInfo: expose the getter
 
 ```cpp
 const std::string& GetImage(symbol i) const;
 ```
 
-Returns the image path for symbol `i`, or empty string if none.
+Returns the image path for symbol `i`, or an empty string if there is none.
 
 #### 4. C API: one new function
 
 ```c
-// Returns the image path for symbol `index`, or empty string if no image.
+// Returns the image path for symbol `index`, or an empty string if no image.
 // The path is relative to the alphabet's data directory.
 // Returns 0 on success, -1 on error.
 DASHER_API int dasher_get_alphabet_symbol_image(
@@ -94,15 +133,15 @@ DASHER_API int dasher_get_alphabet_symbol_image(
 );
 ```
 
-That's the entire API surface. One function.
+That is the entire API surface: one function.
 
 ### Frontend usage pattern
 
-Both Strand 1 and Strand 2 frontends use the same pattern — query once, cache,
-substitute at render time:
+Command-buffer frontends and node-tree frontends use the same pattern: query
+once, cache, and substitute at draw time.
 
 ```swift
-// At startup or when alphabet changes
+// At startup or when the alphabet changes
 var imageMap: [String: NSImage] = [:]
 let count = dasher_get_alphabet_symbol_count(ctx)
 for i in 0..<count {
@@ -114,7 +153,7 @@ for i in 0..<count {
     }
 }
 
-// During rendering — same for Strand 1 and Strand 2
+// During rendering — the same for command-buffer and node-tree rendering
 if let img = imageMap[label] {
     draw(img, in: rect)
 } else {
@@ -122,22 +161,22 @@ if let img = imageMap[label] {
 }
 ```
 
-The lookup table is small (typically 30–50 symbols for a phoneme alphabet),
-built once, and only rebuilt when the user switches alphabet. This is the
-same pattern frontends already use for palette colours.
+The lookup table is small (typically 30–50 symbols for a phoneme alphabet). It
+is built once and rebuilt only when the user switches alphabet. This is the same
+pattern frontends already use for palette colours.
 
 ### Image format and sizing
 
-- **Format**: PNG with alpha (transparency). JPEG acceptable for photographic
-  symbols. SVG is a future option but not required for v1.
-- **Sizing**: images are scaled to fit the Dasher box at render time, same
-  as text labels are sized to fit.
-- **Compositing**: the palette's `fill_argb` fills the box background; the
-  image is drawn on top.
+- **Format:** PNG with alpha (transparency). JPEG is acceptable for photographic
+  symbols. SVG is a future option, not required for v1.
+- **Sizing:** the frontend scales the image to fit the Dasher box at draw time.
+  See the honest assessment above: this is the hard part.
+- **Compositing:** the palette `fill_argb` fills the box background; the image
+  is drawn on top.
 
 ### User-supplied image sets
 
-Users create custom alphabets with their own images:
+A user can create a custom alphabet with their own images:
 
 ```xml
 <node label="cat" image="user_symbols/cat.png">
@@ -145,138 +184,155 @@ Users create custom alphabets with their own images:
 </node>
 ```
 
-Image files are placed alongside the alphabet XML in the user data directory.
-This enables teachers, clinicians, or users to import PCS/Bliss symbol sets,
-create custom phoneme image sets, or mix text and image labels in the same
-alphabet.
+The image files sit alongside the alphabet XML in the user data directory. This
+lets a teacher, a clinician, or a user import PCS or Bliss symbol sets, build a
+custom phoneme image set, or mix text and image labels in one alphabet.
 
-## Relationship to RFC 0013 (custom rendering)
+## Relationship to RFC 0013 (node-tree rendering)
 
-No tension. RFC 0013 introduced two rendering strands:
-- **Strand 1** (command buffer): frontend decodes `int[]` opcodes and renders
-- **Strand 2** (custom rendering): frontend queries node tree via
-  `dasher_get_visible_nodes` and renders from scratch
+No tension. RFC 0013 defines two rendering paths:
 
-This RFC adds **one C API function** that works identically for both strands.
-The frontend queries image paths independently of the rendering path it
-chooses. There is:
-- No `image_index` field added to `dasher_node_info` (Strand 2 doesn't need
-  it — the frontend already has the mapping)
-- No `ImageLabel` class in DasherCore (Strand 1 doesn't need it — the
-  frontend substitutes before calling `DrawString`)
-- No new command buffer opcodes
+- **Command-buffer rendering** — the frontend decodes the `int[]` opcodes and
+  draws them.
+- **Node-tree rendering** — the frontend queries the node tree through
+  `dasher_get_visible_nodes` and draws from scratch.
 
-The engine carries the metadata (image path in the alphabet definition); the
-frontend decides how to render it. This is the same separation as colours:
-the engine carries palette values, the frontend paints pixels.
+This RFC adds **one C API function** that works the same way for both paths. The
+frontend queries the image paths independently of the rendering path it chooses.
+There is:
+
+- No `image_index` field added to `dasher_node_info` (a node-tree frontend does
+  not need it — it already has the mapping).
+- No `ImageLabel` class in DasherCore (a command-buffer frontend does not need
+  it — it substitutes the image before it calls `DrawString`).
+- No new command-buffer opcode.
+
+The engine carries the metadata (the image path in the alphabet definition); the
+frontend decides how to draw it. This is the same split as colours: the engine
+carries the palette values; the frontend paints the pixels.
 
 ## Drawbacks
 
-- **Per-frontend substitution code.** Each frontend implements the lookup
-  table and image rendering (~10–20 lines). This is trivial and follows the
-  existing pattern for palette colour caching.
-- **Bundle size.** Image sets add to app bundle size. A 42-phoneme set at
-  128×128 PNG is ~500 KB. Negligible.
-- **Licensing.** Jolly Phonics images are copyrighted. Users provide their
-  own image sets. The alphabet XML references paths; the engine does not
-  bundle images.
+- **Per-frontend substitution code.** Each frontend implements the lookup table
+  and the image drawing (about 10–20 lines). This is trivial and follows the
+  existing pattern for palette-colour caching.
+- **Bundle size.** An image set adds to the app bundle size. A 42-phoneme set at
+  128×128 PNG is about 500 KB. Negligible.
+- **Licensing.** Jolly Phonics images are copyrighted. Users provide their own
+  image sets. The alphabet XML references paths; the engine does not bundle
+  images.
+- **Dynamic sizing is hard** (see the honest assessment above). This is the real
+  drawback, and it is why uptake is macOS-only for now.
 
 ## Alternatives considered
 
-### A. Two mechanisms (Label class for Strand 1, image_index for Strand 2)
+### A. Two mechanisms (a `Label` class for command-buffer rendering, an `image_index` for node-tree rendering)
 
-Proposed in an earlier draft of this RFC. Rejected because:
-- Creates two code paths for the same feature
-- The Label class approach only works for in-process frontends (GTK), not C
-  API frontends (Apple, Windows, Web) — the command buffer carries text, not
-  image paths
-- Forces frontend devs to understand which strand they're on before
-  implementing image labels
-- More DasherCore internal changes for no benefit
+This was an earlier draft of the RFC. Rejected because:
 
-### B. New command buffer opcode for images
+- It creates two code paths for one feature.
+- The `Label` class only works for in-process frontends (GTK), not for C-API
+  frontends (Apple, Windows, web). The command buffer carries text, not image
+  paths.
+- It forces a frontend dev to work out which path they are on before they
+  implement image labels.
+- It needs more DasherCore changes for no benefit.
 
-Add opcode 8 carrying image data. Rejected because:
-- The command buffer is already at 7 opcodes
-- Image paths or data through an `int[]` buffer is awkward
-- Adds decoding complexity to every Strand 1 frontend
+### B. A new command-buffer opcode for images
 
-### C. Frontend-only config file (no DasherCore changes)
+Add opcode 8 to carry image data. Rejected because:
 
-Each frontend ships a JSON/plist mapping labels to image paths. Rejected
+- The command buffer is already at seven opcodes.
+- Image paths or data through an `int[]` buffer is awkward.
+- It adds decoding work to every command-buffer frontend.
+
+### C. A frontend-only config file (no DasherCore changes)
+
+Each frontend ships a JSON or plist map from labels to image paths. Rejected
 because:
-- The mapping is disconnected from the alphabet definition
-- Creating a new alphabet requires also creating per-frontend config files
-- Not portable — a phoneme alphabet with images should work on all platforms
 
-### D. Strand 2 only
+- The map is disconnected from the alphabet definition.
+- A new alphabet would also need per-frontend config files.
+- It is not portable: a phoneme alphabet with images should work on every
+  platform.
 
-Require Strand 2 for image support. Rejected because:
-- Most frontends use Strand 1
-- Forcing Strand 2 adoption just for image labels is disproportionate
+### D. Node-tree rendering only
+
+Require node-tree rendering for image support. Rejected because:
+
+- Most frontends use the command buffer.
+- Forcing node-tree adoption just for image labels is disproportionate.
 
 ### E. Unicode emoji as image substitutes
 
 Use emoji characters as labels. Rejected because:
-- No phonetically systematic emoji set
-- Coverage incomplete (no emoji for schwa, affricates)
-- Rendering varies by platform/font
+
+- There is no phonetically systematic emoji set.
+- Coverage is incomplete (no emoji for schwa or affricates).
+- Rendering varies by platform and font.
 
 ## Prior art
 
-- **Trinh et al. (2012, 2014)**: iSCAN used Jolly Phonics images (42
-  pictorial phoneme cards) with phoneme prediction. Images were essential
-  for pre-literate users.
-- **Tobii Communicator, Proloquo2Go, Snap Core First**: commercial AAC apps
-  with image-based symbol sets (PCS, Bliss). All support custom image sets.
-- **CSS `content: url()`**: web analogy — text content replaced by an image
-  at render time. Semantic content unchanged; visual representation changes.
+- **Trinh et al. (2012, 2014):** iSCAN used Jolly Phonics images (42 pictorial
+  phoneme cards) with phoneme prediction. The images were essential for
+  pre-literate users.
+- **Tobii Communicator, Proloquo2Go, Snap Core First:** commercial AAC apps with
+  image-based symbol sets (PCS, Bliss). All support custom image sets.
+- **CSS `content: url()`:** a web analogy — text content replaced by an image at
+  draw time. The semantic content is unchanged; only the visual representation
+  changes.
 
 ## Testing
 
 Per [RFC 0011](./0011-testing.md):
 
 - **DasherCore unit tests** (`tests/`):
-  - Verify `AlphIO` parses `image` attribute from a test alphabet XML.
-  - Verify `GetImage(iSymbol)` returns correct path.
-  - Verify `dasher_get_alphabet_symbol_image` returns correct path and
-    handles errors (invalid index, null buffer).
-  - Verify backward compatibility: alphabets without `image` attributes
-    return empty string for all symbols.
-
-- **Frontend (manual)**:
-  - Create a test alphabet with a few image-labelled symbols.
-  - Verify images render in Dasher boxes at various sizes.
-  - Verify text fallback when image file is missing.
-  - Verify mixed text/image alphabets render correctly.
+  - Verify that `AlphIO` parses the `image` attribute from a test alphabet XML.
+  - Verify that `GetImage(iSymbol)` returns the correct path.
+  - Verify that `dasher_get_alphabet_symbol_image` returns the correct path and
+    handles errors (an invalid index, a null buffer).
+  - Verify backward compatibility: an alphabet without `image` attributes
+    returns an empty string for every symbol.
+- **Frontend (manual):**
+  - Build a test alphabet with a few image-labelled symbols.
+  - Verify that images render in Dasher boxes at several sizes.
+  - Verify the text fallback when an image file is missing.
+  - Verify that a mixed text-and-image alphabet renders correctly.
 
 ## Unresolved questions
 
-1. **SVG support.** Should v1 accept SVG for crisp rendering at all sizes?
-   Adds parsing complexity per platform. PNG at 128×128 is simpler.
-
-2. **Runtime image-set switching.** Should users swap image sets at runtime
-   (e.g., Jolly Phonics ↔ PCS) without changing the alphabet XML? Could be a
-   frontend settings option that overrides the image directory prefix.
-
-3. **Image aspect ratio handling.** Dasher boxes vary in aspect ratio.
-   Images could be stretched, letterboxed, or cropped. Text labels use a
-   single font size; images may need different sizing logic.
+1. **SVG support.** Should v1 accept SVG for crisp rendering at all sizes? It
+   adds parsing work per platform. PNG at 128×128 is simpler.
+2. **Runtime image-set switching.** Should a user swap image sets at runtime (for
+   example, Jolly Phonics ↔ PCS) without changing the alphabet XML? This could
+   be a frontend setting that overrides the image-directory prefix.
+3. **Image aspect-ratio handling.** Dasher boxes vary in aspect ratio. Images
+   could be stretched, letterboxed, or cropped. Text labels use one font size;
+   images may need different sizing logic. (See the honest assessment: this is
+   the open hard problem.)
 
 ## Resolution
 
-_(Filled in once a decision is reached.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- Status: _accepted (engine API implemented; macOS frontend implemented; uptake
+  is experimental and not planned for every platform)_
+- Decided by: _maintainers_
+- Date: _2026-08-01_
+- Decision: _The one-function C API lands. It is cheap in the engine. Frontend
+  uptake stays with the platforms that have a concrete need. The dynamic
+  sizing problem and the experimental phoneme work are recorded honestly so a
+  reader does not over-estimate the feature._
 
 ## History
 
-- 2026-07-31 — initial proposal. Motivated by phoneme-based AAC work and
+- 2026-07-31 — initial proposal. Motivated by the phoneme-based AAC work and the
   Trinh et al. papers on phoneme prediction for non-literate users.
-- 2026-07-31 — simplified from two-mechanism design (Label class + node_info
-  field) to single C API function after identifying that Strand 1/Strand 2
-  tension was unnecessary. The frontend query-and-cache pattern works
-  identically for both strands with no engine rendering changes.
+- 2026-07-31 — simplified from a two-mechanism design (a `Label` class plus a
+  `node_info` field) to one C API function, after it became clear that the
+  command-buffer / node-tree tension was unnecessary. The frontend
+  query-and-cache pattern works the same way for both paths, with no engine
+  drawing changes.
+- 2026-08-01 — renamed the rendering paths from "Strand 1 / Strand 2" to
+  **command-buffer rendering** and **node-tree rendering** (per RFC 0013). Added
+  the honest implementation status: engine and macOS-only frontend landed;
+  dynamic image sizing is hard; the phoneme-symbol use case is experimental;
+  not planned for every platform.

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -54,19 +54,25 @@ This keeps RFCs readable for someone arriving fresh.
 
 ## Index
 
+The `Status` column is the RFC's lifecycle state (see above). Most RFCs now carry
+an `## Implementation status` section that records, platform by platform, what is
+actually built. Read that section for the real picture — `implemented` often
+means "landed on some platforms, not all."
+
 | # | Title | Status | Platforms |
 | --- | --- | --- | --- |
 | _0000_ | _(`0000-template.md` — not a real RFC)_ | — | — |
-| [0001](./0001-analytics.md) | Privacy-preserving analytics and crash reporting | proposed | apple, windows, gtk, android |
-| [0002](./0002-lucide-icons.md) | Adopt Lucide as the cross-platform icon set | proposed | apple, windows, gtk, android |
-| [0003](./0003-multilingual-ui.md) | Multilingual UI support across all frontends | proposed | apple, windows, gtk, android, core |
+| [0001](./0001-analytics.md) | Privacy-preserving analytics and crash reporting | implemented | apple, windows, gtk, android |
+| [0002](./0002-lucide-icons.md) | Adopt Lucide as the cross-platform icon set | implemented | apple, windows, gtk, android |
+| [0003](./0003-multilingual-ui.md) | Multilingual UI support across all frontends | active | apple, windows, gtk, android, core |
 | [0004](./0004-onboarding.md) | First-run onboarding experience | proposed | apple, windows, gtk, android, core |
-| [0005](./0005-v5-migration.md) | Dasher v5 → v6 migration: settings, alphabets, and user data | proposed | apple, windows, gtk, core |
-| [0006](./0006-settings-ia.md) | Settings information architecture and progressive disclosure | proposed | apple, windows, gtk, android, core |
-| [0007](./0007-dark-mode-palettes.md) | Dark mode support via appearance-aware colour palettes | proposed | apple, windows, gtk, android, web, core |
+| [0005](./0005-v5-migration.md) | Dasher v5 → v6 migration: settings, alphabets, and user data | implemented | apple, windows, gtk, core |
+| [0006](./0006-settings-ia.md) | Settings information architecture and progressive disclosure | implemented | apple, windows, gtk, android, core |
+| [0007](./0007-dark-mode-palettes.md) | Dark mode support via appearance-aware colour palettes | implemented | apple, windows, gtk, android, web, core |
 | [0008](./0008-keyboard-onboarding.md) | Keyboard extension / IME onboarding (Apple & Android) | proposed | apple, android, core |
-| [0009](./0009-crash-reporting.md) | Crash reporting & engine diagnostics capture | proposed | apple, windows, gtk, android, core |
-| [0010](./0010-input-access-methods.md) | Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick) | draft | apple, windows, gtk, android, core |
-| [0011](./0011-testing.md) | Testing expectations for RFCs | proposed | apple, windows, gtk, android, web, core |
-| [0012](./0012-typing-rate.md) | Typing rate (CPS / WPM) display | proposed | apple, windows, gtk, android, core |
-| [0013](./0013-custom-rendering.md) | Custom rendering API (two-strand) | proposed | apple, windows, gtk, android, web, core |
+| [0009](./0009-crash-reporting.md) | Crash reporting & engine diagnostics capture | implemented | apple, windows, gtk, android, core |
+| [0010](./0010-input-access-methods.md) | Input & access methods (steering/selection/dwell/switch/eye-gaze/joystick) | active | apple, windows, gtk, android, core |
+| [0011](./0011-testing.md) | Testing expectations for RFCs | active | apple, windows, gtk, android, web, core |
+| [0012](./0012-typing-rate.md) | Typing rate (CPS / WPM) display | implemented | apple, windows, gtk, android, core |
+| [0013](./0013-custom-rendering.md) | Node-tree rendering API (custom rendering) | active | apple, windows, gtk, android, web, core |
+| [0014](./0014-image-labels.md) | Image labels for alphabet symbols | implemented | apple, windows, gtk, android, web, core |


### PR DESCRIPTION
## Summary

Audits every v6 frontend (Dasher-Apple, Dasher-Windows, Dasher-GTK, Dasher-Mobile, dasher-web) and DasherCore against each RFC, then records the real, platform-by-platform state. Written in Simplified Technical English.

## What changed

- **New `## Implementation status` section in every RFC (0001–0014)** — an honest per-platform table (implemented / partial / not started) with file evidence, audited August 2026.
- **Corrected frontmatter status** to match reality:
  - `implemented`: 0001, 0002, 0005, 0006, 0007, 0009, 0012, 0014
  - `active`: 0003, 0011, 0013
  - `proposed`: 0004, 0008
  - `draft`: 0010
- **Restored RFC 0013** (it lived on an unmerged branch and never reached `main`) and **added RFC 0014**; the README index now lists both.
- **Renamed the rendering paths**: "Strand 1 / Strand 2" are meaningless names → **command-buffer rendering** and **node-tree rendering** throughout 0013 and 0014.
- **Template (0000)** got an `Implementation status` prompt so future RFCs follow suit.

## Honest calls on 0013 / 0014

These are Dasher-Apple only and experimental; there is no plan to bring them to every platform.

- **0014 image labels** — engine + macOS frontend landed. Dynamic image sizing in the command-buffer model is hard and the result is not great; the phoneme-symbol driver is experimental; no bundled alphabet uses `image=` yet.
- **0013 node-tree rendering** — engine API landed and tested, but **no production frontend uses it**. The DasherMac cube branch is experimental and buggy. The most promising future use is a spatial eye-tracked port (e.g. Meta Quest foveated eye tracking).

## Out of scope (tracked separately)

Cross-repo follow-ups — the **website status matrix** at `dasher.at/status/` and per-frontend tasks (e.g. Windows typing-rate, GTK DasherCore bump + C-API adoption, Android rebase off its divergent fork, Apple visionOS analytics opt-in) — are tracked in a local `RFC-FOLLOWUPS.md` kept **outside** this repo, and are intentionally not part of this PR.

## Reviewer notes

- Status calls are evidence-based; each RFC's status section names the files. Push back on any call that looks wrong and I'll re-point it.
- `implemented` in the index means "landed somewhere", not "on every platform" — the index note says so, and the per-RFC table gives the detail.
- RFCs 0004 (onboarding) and 0008 (keyboard onboarding) stay `proposed` — neither is meaningfully built; both need UX work first.
- RFC 0010 stays `draft` — the access-method matrices on Apple and Windows still diverge.
