### PR TITLE
rfcs: triage Resolutions & Unresolved questions to match lifecycle state

### DIFF
--- a/rfcs/0000-template.md
+++ b/rfcs/0000-template.md
@@ -73,16 +73,24 @@ but reviewers are expected to ask about it.
 
 ## Unresolved questions
 
-What do you want input on before this is finalised?
+What do you want input on before this is finalised? Mark each item as it
+evolves: **Resolved (YYYY-MM-DD).** / **Open.** / **Superseded.** An RFC that is
+`active` or `implemented` is accepted overall; it may still carry named open
+sub-questions (list them in Resolution under "Open sub-questions").
 
 ## Resolution
 
 _(Filled in once a decision is reached — do not fill in when proposing.)_
 
-- Status: _accepted / rejected_
+- State: _pending — open for discussion | accepted | implemented | rejected | withdrawn_
 - Decided by: _maintainers + stewards_
 - Date: _YYYY-MM-DD_
-- Decision: _short rationale_
+- Decision: _short rationale; for `implemented`, name where it shipped_
+- Open sub-questions: _none, or list by number — see Unresolved questions_
+
+`State` mirrors the lifecycle: `pending` while `draft`/`proposed`; `accepted`
+when `active`; `implemented` when landed. Acceptance does not require every
+sub-question closed — name the ones that stay open.
 
 ## History
 

--- a/rfcs/0001-analytics.md
+++ b/rfcs/0001-analytics.md
@@ -234,22 +234,26 @@ Rely on OS-level telemetry (Windows Diagnostic Data, macOS analytics).
 
 ## Unresolved questions
 
-1. **Who hosts the PostHog instance?** Will Wade initially? A cloud VM
-   under the dasher-project org? Cost implications?
-2. **Data retention period?** Propose 13 months (aligns with PostHog
-   defaults), but open to discussion.
+1. **Who hosts the PostHog instance?** **Resolved (2026-08-01).** A self-hosted
+   PostHog instance is live; Apple (iOS, macOS) and Windows ship against it.
+2. **Data retention period?** **Open.** Proposed 13 months (the PostHog default).
+   Confirm against the configured value on the live instance.
 3. **Should crash reporting be opt-in separately from usage analytics?**
-   Some projects allow crash reporting even when usage analytics are off.
-4. **Do we need a consent flow per platform, or is a single project-wide
-   privacy policy sufficient?**
-5. **Should the event schema live in DasherCore (shared) or in each
-   frontend repo?**
+   **Resolved (2026-08-01).** No. Crashes use the same opt-in, specified in
+   [RFC 0009](./0009-crash-reporting.md).
+4. **Do we need a consent flow per platform, or is a single project-wide privacy
+   policy sufficient?** **Resolved (2026-08-01).** One published event schema,
+   with a per-platform opt-in prompt (Apple and Windows ship it).
+5. **Should the event schema live in DasherCore (shared) or in each frontend
+   repo?** **Resolved (2026-08-01).** Per-frontend. Apple and Windows each ship
+   their own `analytics-events.json`.
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: Opt-in PostHog analytics shipped on Dasher-Apple (iOS, macOS) and
+  Dasher-Windows. GTK, Android, and web have not started. Crashes fold into the
+  same opt-in via [RFC 0009](./0009-crash-reporting.md).
+- Open sub-questions: Q2 (confirm the configured retention period).

--- a/rfcs/0002-lucide-icons.md
+++ b/rfcs/0002-lucide-icons.md
@@ -211,14 +211,23 @@ maintenance burden described in Motivation.
 
 1. **`lucide-icons-swift` maintainership** — should we pin to a specific tagged
    release or track `main`? Should we consider forking preemptively?
+   **Open.** Low priority; the package is in use at 1.20+.
 2. **Accessibility labels** — should icon `aria-label` / accessibility
    identifier be derived from the Lucide icon name, or maintained separately?
-3. **Dark mode** — Lucide icons are monochrome so theming is straightforward,
-   but do we need separate "filled" variants for active states (e.g., solid
-   play vs outline play)?
-4. **visionOS** — does `lucide-icons-swift` render correctly in visionOS
-   windows, or do we need SF Symbols as a visionOS-specific fallback?
+   **Resolved (2026-08-01).** Icons are decorative monochrome marks; the
+   surrounding label text (`LucideLabel`) provides the accessible name.
+3. **Dark mode** — do we need separate "filled" variants for active states?
+   **Resolved (2026-08-01).** No. Icons are single-stroke monochrome and theme
+   through the stroke colour, per [RFC 0007](./0007-dark-mode-palettes.md).
+4. **visionOS** — does `lucide-icons-swift` render correctly in visionOS?
+   **Resolved (2026-08-01).** Yes — Lucide is in use across iOS, macOS, and
+   visionOS.
 
 ## Resolution
 
-_(To be filled in after community discussion.)_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: Lucide adopted on Dasher-Apple (`lucide-icons-swift`) and
+  Dasher-Windows (`Lucide.Avalonia`). GTK, Android, and web have not adopted it.
+- Open sub-questions: Q1 (pin/fork policy for the community Swift package).

--- a/rfcs/0003-multilingual-ui.md
+++ b/rfcs/0003-multilingual-ui.md
@@ -371,26 +371,31 @@ gracefully.
 
 1. **GTK C API adoption** — Should GTK switch to the C API (`dasher_set_locale`)
    for engine strings, or should DasherCore re-generate gettext `.po` files
-   alongside the JSON files? The C API route is recommended but requires GTK to
-   call through `dasher.h` instead of linking C++ classes directly.
+   alongside the JSON files? **Open.** GTK has not adopted the C API yet; the C
+   API route remains the recommendation.
 
 2. **Translation quality bar** — Do we ship machine translations immediately
-   (marked fuzzy), or wait for human review per language? What's the threshold
-   for "good enough" to appear in a release?
+   (marked fuzzy), or wait for human review per language? **Open.** No frontend
+   ships translations yet; the bar is undecided.
 
-3. **Locale vs. alphabet model** — The UI locale (interface language) and the
-   Dasher alphabet model (text output language) are independent. Should changing
-   the UI locale auto-suggest a matching alphabet model? (e.g., selecting French
-   suggests the French alphabet.) Or keep them fully decoupled?
+3. **Locale vs. alphabet model** — Should changing the UI locale auto-suggest a
+   matching alphabet model? **Open.** A UX decision; not yet wired.
 
-4. **Plural forms** — Some languages (Arabic, Russian, Polish) have complex
-   plural rules. Do any frontend strings need plural-aware translation? Most UI
-   strings are labels ("Play", "Copy") not count-based ("3 files"), so this may
-   be a non-issue, but onboarding/error messages could need it.
+4. **Plural forms** — Do any frontend strings need plural-aware translation?
+   **Resolved (2026-08-01).** Most UI strings are labels, not counts, so
+   plural-aware translation is a non-issue for v1.
 
-5. **Keyboard extension (iOS)** — The DasherKeyboard target has its own UI.
-   Does it share the same `.xcstrings` as the main app, or need a separate catalog?
+5. **Keyboard extension (iOS)** — Does `DasherKeyboard` share the same
+   `.xcstrings` as the main app, or need a separate catalog? **Open.** Decided
+   when iOS localisation lands.
 
 ## Resolution
 
-_(To be filled in after community discussion.)_
+- State: accepted
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The two-layer model is accepted. Engine strings localise through
+  `dasher_set_locale` (done — 33 locale files ship). Frontend chrome localises
+  through each platform's native catalog (not started on any frontend). This RFC
+  is the plan of record for the frontend work.
+- Open sub-questions: Q1, Q2, Q3, Q5.

--- a/rfcs/0004-onboarding.md
+++ b/rfcs/0004-onboarding.md
@@ -344,22 +344,22 @@ real Dasher canvas — a web simulation wouldn't reflect their setup.
 
 ## Unresolved questions
 
-1. **UX expert engagement** — Who do we engage, and what's the budget? Is this
-   a pro-bono advisory role or a paid consultation?
-2. **Is a passive demonstration step needed at all?** If the UX research says
-   yes, is it best served by a short video clip (no engine work), a fresh
-   auto-driver built to the current codebase, or by going straight into guided
-   practice? This is a research output, not an engineering decision.
-3. **Beginner mode persistence** — Should sibling suppression and path
-   correction be a first-run-only thing, or a persistent accessibility setting
-   (beginner mode toggle)?
-4. **Cross-platform consistency** — Should onboarding look identical across
-   platforms, or follow each platform's conventions (SwiftUI wizard vs. GTK
-   Assistant)?
-5. **Measurement** — How do we measure whether onboarding reduces abandonment?
-   Analytics (RFC 0001) could track: onboarding completion rate, time-to-first-
-   word, 7-day retention by onboarding path.
+1. **UX expert engagement** — Who do we engage, and what's the budget? **Open.**
+2. **Is a passive demonstration step needed at all?** **Open.** A research
+   output, not an engineering decision.
+3. **Beginner mode persistence** — first-run-only or a persistent setting?
+   **Open.**
+4. **Cross-platform consistency** — identical across platforms, or per-platform
+   conventions? **Open.**
+5. **Measurement** — how do we measure whether onboarding reduces abandonment?
+   **Open.** Analytics ([RFC 0001](./0001-analytics.md)) could track completion
+   rate, time-to-first-word, and retention by path.
 
 ## Resolution
 
-_(To be filled in after community discussion and UX consultation.)_
+- State: pending — open for discussion
+- Decided by: —
+- Date: —
+- Decision: Not yet accepted. The UX research ("Design questions needing UX
+  expert input") is a prerequisite, and no frontend ships onboarding yet.
+- Open sub-questions: all (see Unresolved questions).

--- a/rfcs/0005-v5-migration.md
+++ b/rfcs/0005-v5-migration.md
@@ -573,31 +573,31 @@ because it allows v6 to evolve its storage independently.
 
 ## Unresolved questions
 
-1. **Where does v6 store user data on Windows?** The RFC proposes
-   `%APPDATA%\Dasher\` but this should be confirmed. Windows convention
-   is `%LOCALAPPDATA%\Dasher\` for per-machine data.
+1. **Where does v6 store user data on Windows?** **Resolved (2026-08-01).**
+   Settled by the shipped Windows implementation; see `V5MigrationService` in
+   Dasher-Windows.
 
-2. **Should we bundle common v5 fonts?** Steve Saling uses "Alaska" and
-   "CG Omega". If these are freely redistributable, bundling them would
-   make the migration seamless. Licensing needs checking.
+2. **Should we bundle common v5 fonts?** **Open.** Licensing for "Alaska" and
+   "CG Omega" is unclear; they are not bundled today.
 
-3. **Should the migration be re-runnable?** The RFC proposes an opt-in
-   migration with a Settings > Migration panel for re-import. Should
-   there be a limit on re-runs?
+3. **Should the migration be re-runnable?** **Resolved (2026-08-01).** Yes. The
+   Settings re-import panel shipped on macOS and Windows.
 
-4. **GTK/Linux paths**: Need to verify `~/.dasher/` is still correct and
-   determine where v6 GTK should store user data (XDG `~/.local/share/Dasher/`?).
-   Deferred until GTK frontend exists.
+4. **GTK/Linux paths**: **Open.** GTK migration has not started; verify `~/.dasher/`
+   and the v6 XDG path when it does.
 
-5. **v5 colour index semantics**: v6 may have changed colour index
-   assignments. If a user's custom colour XML assigns specific indices
-   (e.g., index 10 = green for letters), do these still map correctly
-   in v6's rendering engine?
+5. **v5 colour index semantics**: **Resolved (2026-08-01).** Colour XML migrates
+   as-is and parses (the legacy `<colours>` spelling is still supported). No index
+   remapping is needed.
 
-6. **Adaptive training privacy**: The training file contains text the
-   user has typed. Migrating it is essential for prediction quality but
-   means copying potentially sensitive text. Should we warn the user?
+6. **Adaptive training privacy**: **Resolved (2026-08-01).** Training files copy
+   as-is; the opt-in migration prompt tells the user what is imported.
 
 ## Resolution
 
-_(To be filled in after community discussion.)_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: One-shot, opt-in migration shipped on Dasher-Apple (macOS) and
+  Dasher-Windows, with a Settings re-import panel. GTK pending.
+- Open sub-questions: Q2 (bundling v5 fonts), Q4 (GTK/Linux paths).

--- a/rfcs/0006-settings-ia.md
+++ b/rfcs/0006-settings-ia.md
@@ -339,17 +339,25 @@ overwhelmed, and the tier field already exists and is unused.
 
 ## Unresolved questions
 
-1. **Tier audit** — Who runs the card-sort study, and when? Can we crowdsource
-   tier validation from the community (e.g. a survey on the website)?
-2. **Alphabet selection in Simple mode** — Should we promote the alphabet
-   picker to `common` tier so Language tab appears in Simple? Or move alphabet
-   selection to the status bar (where it already lives on some platforms)?
-3. **Pro mode confirmation** — Speed bump or not? (Q4 above)
-4. **GTK timeline** — Dynamic manifest rendering is a prerequisite. When does
-   GTK adopt it?
-5. **Search** — Should we add a settings search bar alongside (not instead of)
-   the tier system?
+1. **Tier audit** — Who runs the card-sort study, and when? **Open.** The card
+   sort has not run; this blocks the three-tier UI.
+2. **Alphabet selection in Simple mode** — promote the alphabet picker to
+   `common` tier, or move it to the status bar? **Open.** Tied to the tier audit.
+3. **Pro mode confirmation** — speed bump or not? **Open.** The tier UI is not
+   built.
+4. **GTK timeline** — when does GTK adopt dynamic manifest rendering?
+   **Resolved (2026-08-01).** GTK now renders dynamically from the parameter
+   schema (the prerequisite is done); it still lacks tier filtering.
+5. **Search** — add a settings search bar alongside the tier system? **Open.** A
+   future enhancement.
 
 ## Resolution
 
-_(To be filled in after community discussion and end-user research.)_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The tab structure and dynamic manifest rendering are implemented on
+  Apple, Windows, GTK, and web (Android partial). The three-tier (Simple /
+  Advanced / Pro) progressive disclosure is not implemented on any platform; it
+  is blocked on the tier-validation card sort.
+- Open sub-questions: Q1, Q2, Q3, Q5.

--- a/rfcs/0007-dark-mode-palettes.md
+++ b/rfcs/0007-dark-mode-palettes.md
@@ -356,23 +356,26 @@ companion lookup covers legacy palettes in the meantime.
 
 ## Unresolved questions
 
-1. **Naming convention** for dark variants — should we standardise on a
-   `"<Name> Dark"` suffix (as shipped), or a separate `appearance`-keyed
-   namespace? A suffix is simpler for the bidirectional companion lookup.
-2. **Default mode for fresh installs** — `SYSTEM` (follow the OS, proposed) vs
-   `LIGHT` (preserve historical Dasher behaviour). With `SYSTEM` and a default
-   `system_appearance = LIGHT`, out-of-the-box rendering is unchanged until a
-   frontend reports otherwise; confirming `SYSTEM` as the default is the open
-   question.
-3. **Settings UI shape** — a single palette list with appearance badges plus a
-   System/Light/Dark mode control, or separate Light/Dark palette pickers (which
-   the dual-preference model already supports)? This may warrant a follow-up to
-   RFC 0006 (settings IA).
-4. **Per-alphabet dark overrides** — some alphabets (e.g. Thai, with its own
-   colour sequences) may need darker-specific group colours. Should we allow a
-   dark palette to override `nodeLabelColorSequence` per group, or is flipping
-   the default label colour always enough?
+1. **Naming convention** for dark variants. **Resolved (2026-08-01).** Standardise
+   on a `"<Name> Dark"` suffix, as shipped.
+2. **Default mode for fresh installs** — `SYSTEM` or `LIGHT`? **Resolved
+   (2026-08-01).** `SYSTEM` is the default; out-of-box rendering is unchanged
+   until a frontend reports the OS appearance.
+3. **Settings UI shape** — a single palette list with badges, or separate
+   Light/Dark pickers? **Resolved (2026-08-01).** Apple ships separate light/dark
+   pickers plus a System/Light/Dark mode control; other frontends follow the same
+   engine API.
+4. **Per-alphabet dark overrides** — allow a dark palette to override
+   `nodeLabelColorSequence` per group, or is flipping the default label colour
+   enough? **Open.** Only the default label colour is flipped today; per-alphabet
+   overrides are not done.
 
 ## Resolution
 
-_(To be filled in after community discussion.)_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The appearance model (mode, system input, dual palette preferences,
+  companion lookup) and eight dark companion palettes shipped in DasherCore.
+  Apple and Windows apply it end-to-end; GTK and Android apply the canvas only.
+- Open sub-questions: Q4 (per-alphabet dark overrides).

--- a/rfcs/0008-keyboard-onboarding.md
+++ b/rfcs/0008-keyboard-onboarding.md
@@ -208,26 +208,21 @@ must be plain-language and localised — they are the scariest step.
 
 ## Unresolved questions
 
-1. **Default-IME detection on Android < 14.** What is the most reliable heuristic
-   that doesn't require a privileged permission? Proposal: treat "enabled and
-   only one IME enabled" as `ready`, else `enabledNotDefault`.
-2. **Re-prompt cadence.** How often should the banner re-appear if the user
-   dismisses it? Once per app launch? Once ever (until they re-open the flow from
-   Settings)?
-3. **Full Access messaging.** Is the AAC-specific framing ("needed so Dasher can
-   speak what you write and remember your training") the right one, or does it
-   over-promise?
+1. **Default-IME detection on Android < 14.** **Open.** Most reliable unprivileged
+   heuristic still to be chosen.
+2. **Re-prompt cadence.** **Open.** Not yet decided.
+3. **Full Access messaging.** **Open.** Copy to be finalised.
 4. **IME-engine sharing.** Should the onboarding flag live in the shared
-  `userDir` (so the IME can also see it) or in the main app's private prefs?
-5. **Does this warrant a small DasherCore C API** (e.g. a "mark keyboard
-   onboarding complete" persisted flag) so all frontends share the SSOT, or is
-   per-frontend persistence correct?
+   `userDir` or in the main app's private prefs? **Open.**
+5. **Does this warrant a small DasherCore C API** ("mark keyboard onboarding
+   complete") so all frontends share the SSOT, or is per-frontend persistence
+   correct? **Open.**
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- State: pending — open for discussion
+- Decided by: —
+- Date: —
+- Decision: Not yet accepted. No frontend ships the keyboard-enablement flow on
+  Apple or Android.
+- Open sub-questions: all (see Unresolved questions).

--- a/rfcs/0009-crash-reporting.md
+++ b/rfcs/0009-crash-reporting.md
@@ -207,22 +207,25 @@ Per [RFC 0011](./0011-testing.md). Defence-in-depth claims should name a test:
 ## Unresolved questions
 
 1. **Android IME process boundary** — should the IME also write a crash file, or
-   only the main app? (Proposal: both, suffixed filenames.)
+   only the main app? **Open.** Android crash reporting has not started.
 2. **Verbose-log opt-in** — copy and placement of "Send verbose logs with crash
-   reports" (Settings → Privacy, per RFC 0006).
-3. **Native symbolication** — accept unsymbolicated native frames in v1 (rely on
-   user-shared `.ips` / dialogs), or revisit a crash SDK later?
+   reports". **Open.** Not built.
+3. **Native symbolication** — accept unsymbolicated native frames, or revisit a
+   crash SDK later? **Resolved (2026-08-01).** v1 accepts unsymbolicated native
+   frames; rely on OS crash logs and user-shared `.ips` files (see "Out of
+   scope").
 4. **Crash-file format convergence** — switch macOS from JSON to the shared text
-   format, or accept both?
+   format, or accept both? **Open.**
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: Engine boundary capture and `dasher_has_engine_error` shipped
+  (DasherCore v0.1.6). Frontend crash reporting shipped on Dasher-Windows and
+  Dasher-Apple (macOS). iOS/visionOS production, GTK, and Android pending.
+- Open sub-questions: Q1, Q2, Q4.
 
 ## History
 

--- a/rfcs/0010-input-access-methods.md
+++ b/rfcs/0010-input-access-methods.md
@@ -252,36 +252,36 @@ all four platforms adopt the same shape.
    selection methods are agreed, the matrix is agreed, and the selection →
    `SP_INPUT_FILTER` mapping will live in `DasherCore/docs` as the SSOT.
    Steering methods stay per-platform (hardware-gated), names shared.
-2. **Switch Access vs. in-app switch capture on mobile.** On Android and iOS,
-   should Dasher consume the **system** switch-access/switch-control events
-   (lower friction, honours the user's existing switch setup) or capture its own
-   (more control, requires the user to re-bind)? This is the biggest open
-   design question.
-3. **UDP gaze protocol.** Is Windows's existing format the right cross-platform
-   standard, or should we define a cleaner JSON/binary format now?
-4. **Android eye-gaze path.** Camera Switch presents as an accessibility
-   service, not a mouse; Tobii on Android presents as a mouse. Which do we
-   target first?
-5. **Dwell rendering in the IME/keyboard extension.** Out of scope, or a
-   reduced-capability version?
-6. **Where does the access-method state live?** Sidecar JSON (per RFC 0007
-   pattern) vs. engine parameters (per RFC 0006 manifest)?
-7. **UX research prerequisite.** What is the minimum user research required
-   before promoting this RFC out of `draft`?
-8. **Does Android need an `AccessibilityService`** (for Switch Access
-   consumption) alongside the existing `InputMethodService`? That has app-store
-   and permission implications worth its own sub-RFC.
+2. **Switch Access vs. in-app switch capture on mobile.** **Open.** Should
+   Dasher consume the system switch-access/switch-control events, or capture its
+   own? This is the biggest open design question and blocks deeper switch work.
+3. **UDP gaze protocol.** **Open.** Is Windows's existing format the right
+   cross-platform standard, or define a cleaner JSON/binary format?
+4. **Android eye-gaze path.** **Open.** Camera Switch presents as an
+   accessibility service; Tobii on Android presents as a mouse. Which first?
+5. **Dwell rendering in the IME/keyboard extension.** **Open.** Out of scope, or
+   a reduced-capability version?
+6. **Where does the access-method state live?** **Open.** Sidecar JSON (per
+   RFC 0007) vs. engine parameters (per RFC 0006).
+7. **UX research prerequisite.** **Resolved (2026-08-01) for promotion** — the
+   RFC moved out of `draft` once the canonical model was agreed. **Open** for the
+   access-screen IA: the compatibility matrix and the access-screen layout still
+   need user research with AAC users and clinicians.
+8. **Does Android need an `AccessibilityService`** for Switch Access alongside
+   the `InputMethodService`? **Open.** App-store and permission implications;
+   may warrant its own sub-RFC.
 
 ## Resolution
 
-- Status: _accepted (canonical model agreed; switch-access design still open)_
-- Decided by: _maintainers_
-- Date: _2026-08-01_
-- Decision: _The nine selection methods, the seven steering methods, and the
+- State: accepted
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The nine selection methods, the seven steering methods, and the
   compatibility matrix are normative. The selection → `SP_INPUT_FILTER` mapping
   is engine-owned and moves to `DasherCore/docs`. Steering methods stay
-  per-platform. The switch-access question (Q2) stays open and blocks deeper
-  switch work, not the model itself._
+  per-platform.
+- Open sub-questions: Q2 (switch-access design) is the main one — it blocks
+  deeper switch work, not the model. Q3–Q8 remain open.
 
 ## History
 

--- a/rfcs/0011-testing.md
+++ b/rfcs/0011-testing.md
@@ -158,29 +158,25 @@ with no test will (and should) ask.
 
 1. Should DasherCore grow a small shared test harness for the analytics event
    schema and the crash scrubber, so every frontend runs the same assertions
-   against the same fixture set?
+   against the same fixture set? **Open.** Not built. The broader point stands:
+   cross-frontend invariant tests on the C-API contract are the highest-leverage
+   tests. A bug that only *manifests* on one frontend is very often a DasherCore
+   bug that any frontend could trip (the v5 alphabet name-collision was the
+   cautionary example).
 
-   More broadly: **cross-frontend invariant tests on the C API contract are the
-   highest-leverage tests we have.** DasherCore's existing draw-command tests,
-   alphabet-parsing tests, and parameter-lifecycle tests catch bugs that would
-   otherwise surface as platform-specific regressions — and a bug that only
-   *manifests* on one frontend is very often a DasherCore bug that any frontend
-   could have tripped. The v5 alphabet bug is the cautionary example: it
-   appeared to be a Windows-only regression because v5 migration only runs
-   there, but the root cause (a name collision overwriting the default
-   alphabet) was in DasherCore and could have hit any frontend. Tests that
-   assert the shared invariants — independent of whichever frontend exposed
-   the symptom — are worth more than the sum of the per-frontend equivalents.
 2. Do we want CI to **report** test coverage per repo (a status check) even
-   though it isn't a gate?
+   though it isn't a gate? **Open.** Not wired.
+
 3. When Apple wires `testTargets` in `project.yml`, does that count as a
-   prerequisite for this RFC or a follow-up?
+   prerequisite for this RFC or a follow-up? **Open.** Apple's `testTargets` is
+   still `[]`.
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- State: accepted
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: Adopted as guidance (not a gate). The Testing section is in the
+  template; the README cross-references this RFC. DasherCore and Dasher-Windows
+  have active test suites; the other frontends do not.
+- Open sub-questions: Q1, Q2, Q3.

--- a/rfcs/0012-typing-rate.md
+++ b/rfcs/0012-typing-rate.md
@@ -139,21 +139,24 @@ Per [RFC 0011](./0011-testing.md):
 
 ## Unresolved questions
 
-1. **Window length / pause threshold** — 5 s / 2 s proposed; tune with feedback?
-2. **Where the regular-use toggle lives** — "Output" group vs a new "Statistics"
-   group (RFC 0006 IA)?
-3. **Net vs gross WPM** — ship gross first, add net (error-adjusted) later?
+1. **Window length / pause threshold** — 5 s / 2 s proposed. **Resolved
+   (2026-08-01).** Shipped in the engine as a 5 s window with a 2 s pause freeze.
+2. **Where the regular-use toggle lives** — "Output" group or a new "Statistics"
+   group? **Resolved (2026-08-01).** Apple ships a Settings toggle
+   (`showTypingRate`) in the Output/statistics area.
+3. **Net vs gross WPM** — ship gross first? **Resolved (2026-08-01).** Yes; gross
+   for v1, net (error-adjusted) is a future option.
 4. **PostHog aggregate** — send session-average WPM as an analytics property?
-   (Privacy-safe; non-content.)
+   **Open.** Not sent today; privacy-safe, non-content.
 
 ## Resolution
 
-_(Filled in once a decision is reached — do not fill in when proposing.)_
-
-- Status: _pending_
-- Decided by: _pending_
-- Date: _pending_
-- Decision: _pending_
+- State: implemented
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: Engine API (`dasher_get_wpm`, `dasher_get_cps`) shipped. Apple (iOS,
+  macOS) and web show live WPM. Windows, GTK, and Android pending.
+- Open sub-questions: Q4 (session-average WPM as an analytics property).
 
 ## History
 

--- a/rfcs/0013-custom-rendering.md
+++ b/rfcs/0013-custom-rendering.md
@@ -295,21 +295,21 @@ Per [RFC 0011](./0011-testing.md):
 
 ## Unresolved questions
 
-1. **Should the engine still emit opcode 7 (cube data)** for frontends that want
-   the two-pass approach, or withdraw it entirely in favour of node-tree
-   rendering? (Recommendation: withdraw.)
-2. **Colour palette access.** Should the API expose the palette directly
+1. **Should the engine still emit opcode 7 (cube data)** for the two-pass
+   approach, or withdraw it? **Open.** Recommendation: withdraw.
+2. **Colour palette access.** **Open.** Expose the palette directly
    (`dasher_get_palette_colors`), or only the per-node colours in
    `dasher_node_info`?
 
 ## Resolution
 
-- Status: _accepted (engine API implemented; no production frontend yet)_
-- Decided by: _maintainers_
-- Date: _2026-08-01_
-- Decision: _The C API lands as the second rendering path. It is opt-in and
-  coexists with the command buffer. There is no plan to bring it to every
-  platform; it exists for frontends that need full visual control._
+- State: accepted (engine API implemented; no production frontend yet)
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The node-tree API lands as the second rendering path. It is opt-in
+  and coexists with the command buffer. There is no plan to bring it to every
+  platform; it exists for frontends that need full visual control.
+- Open sub-questions: Q1, Q2.
 
 ## History
 

--- a/rfcs/0014-image-labels.md
+++ b/rfcs/0014-image-labels.md
@@ -301,26 +301,24 @@ Per [RFC 0011](./0011-testing.md):
 
 ## Unresolved questions
 
-1. **SVG support.** Should v1 accept SVG for crisp rendering at all sizes? It
-   adds parsing work per platform. PNG at 128×128 is simpler.
-2. **Runtime image-set switching.** Should a user swap image sets at runtime (for
-   example, Jolly Phonics ↔ PCS) without changing the alphabet XML? This could
-   be a frontend setting that overrides the image-directory prefix.
-3. **Image aspect-ratio handling.** Dasher boxes vary in aspect ratio. Images
-   could be stretched, letterboxed, or cropped. Text labels use one font size;
-   images may need different sizing logic. (See the honest assessment: this is
-   the open hard problem.)
+1. **SVG support.** **Open.** PNG at 128×128 for v1; SVG is a future option.
+2. **Runtime image-set switching.** **Open.** Could be a frontend setting that
+   overrides the image-directory prefix.
+3. **Image aspect-ratio handling.** **Open.** The hard problem — see the honest
+   assessment. Dasher boxes vary in aspect ratio; images could be stretched,
+   letterboxed, or cropped.
 
 ## Resolution
 
-- Status: _accepted (engine API implemented; macOS frontend implemented; uptake
-  is experimental and not planned for every platform)_
-- Decided by: _maintainers_
-- Date: _2026-08-01_
-- Decision: _The one-function C API lands. It is cheap in the engine. Frontend
+- State: implemented (engine API; macOS frontend; uptake is experimental and not
+  planned for every platform)
+- Decided by: maintainers
+- Date: 2026-08-01
+- Decision: The one-function C API lands. It is cheap in the engine. Frontend
   uptake stays with the platforms that have a concrete need. The dynamic
   sizing problem and the experimental phoneme work are recorded honestly so a
-  reader does not over-estimate the feature._
+  reader does not over-estimate the feature.
+- Open sub-questions: Q1, Q2, Q3.
 
 ## History
 


### PR DESCRIPTION
## Summary

Follow-up to #22 (which was squash-merged while GitHub's PR head was stale, so this commit did not make it in). Brings every RFC's `Resolution` and `Unresolved questions` into line with its lifecycle status.

## What changed

The audit in #22 bumped 0001–0009, 0011, 0012 to `implemented`/`active`, but their `Resolution` sections still said "pending" and their `Unresolved questions` read as fully open. This commit fixes that:

- **`## Resolution`** — filled for every RFC with `State` / `Decided by` / `Date` / `Decision` / `Open sub-questions`, mapped from the status:
  - `implemented` → State `implemented`
  - `active` → State `accepted` (with named open sub-questions)
  - `proposed` → State `pending — open for discussion`
- **`## Unresolved questions`** — every item triaged as `**Resolved (date).**` / `**Open.**` / `**Superseded.**` against the August 2026 audit.
- Normalised 0010 / 0013 / 0014 to the same convention.
- Documented the convention in the template (0000): `State` mirrors lifecycle; an active/implemented RFC is accepted overall and may still carry named open sub-questions.

**No `status` values are changed here** — only the Resolution and Unresolved sections, plus the template.

## Verification

Checked that every RFC's frontmatter `status` matches its Resolution `State`, and that every Unresolved question carries a marker.
