### PR TITLE
RFC 0015: direct-entry mode (proposed) + RFC 0005 v5 behaviour-parity notes

### DIFF
--- a/rfcs/0005-v5-migration.md
+++ b/rfcs/0005-v5-migration.md
@@ -4,7 +4,7 @@ title: "Dasher v5 → v6 migration: settings, alphabets, and user data"
 status: implemented
 platforms: [apple, windows, gtk]
 created: 2026-06-18
-updated: 2026-08-01
+updated: 2026-08-21
 ---
 
 # Dasher v5 → v6 migration: settings, alphabets, and user data
@@ -276,6 +276,30 @@ categories of genuinely-missing functionality are:
 The migration report should list these as "Not yet available" rather
 than silently dropping them. This transparency builds trust with
 long-time users who may be looking for specific functionality.
+
+### Behaviour parity beyond settings
+
+Migrating the stored values is not enough if the v6 UI then clamps or
+reinterprets them. Two requirements for every frontend, learned from a v6
+first-impressions report (2026-08) where a v5 user's speed was unreachable and
+"New" did not reset context:
+
+1. **Speed controls must accept the full v5 range.** v5's UI offered
+   0.1–8.0 (`MaxBitRateTimes100` = raw 10–800; Steve Saling's 700 is a real
+   value). Migration must write `LP_MAX_BITRATE` **directly** — the
+   `dasher_set_speed_percent` helper clamps to 20–400 %, i.e. raw 32–640,
+   which silently truncates the top of v5's range — and every speed control
+   (footer spinners, mini-bars) must accept at least raw 10–800, taking its
+   range from the engine manifest rather than hardcoding. Dasher-GTK's footer
+   capped at 400 until [Dasher-GTK #51](https://github.com/dasher-project/Dasher-GTK/pull/51);
+   the engine manifest allows 1–1000.
+2. **"New" is a full reset.** v5's New cleared the editor *and* dropped the
+   prediction context (via `SetBuffer(0)`). The v6 equivalent is
+   `dasher_reset()` (clear text **and** restart the model), not
+   `dasher_reset_output_text()` (clear text, keep the learned position — the
+   canvas resumes mid-sentence). Dasher-Windows and Dasher-Apple already did
+   this; Dasher-GTK was aligned in #51. "Open file" keeps using the softer
+   `dasher_reset_output_text()`.
 
 ### Custom user data migration
 
@@ -601,3 +625,11 @@ because it allows v6 to evolve its storage independently.
 - Decision: One-shot, opt-in migration shipped on Dasher-Apple (macOS) and
   Dasher-Windows, with a Settings re-import panel. GTK pending.
 - Open sub-questions: Q2 (bundling v5 fonts), Q4 (GTK/Linux paths).
+
+## History
+
+- _2026-06-18_ — _(initial proposal)_
+- _2026-08-01_ — _implementation-status audit; resolution recorded_
+- _2026-08-21_ — _added "Behaviour parity beyond settings" (speed-range floor
+  of raw 10–800, New = full reset) after a v6 first-impressions report;
+  see [Dasher-GTK #51](https://github.com/dasher-project/Dasher-GTK/pull/51)_

--- a/rfcs/0015-direct-entry-mode.md
+++ b/rfcs/0015-direct-entry-mode.md
@@ -1,0 +1,216 @@
+---
+rfc: 0015
+title: Direct-entry mode (typing into other applications)
+status: proposed
+platforms: [apple, windows, gtk, android, core]
+created: 2026-08-21
+updated: 2026-08-21
+---
+
+# Direct-entry mode (typing into other applications)
+
+## Summary
+
+Dasher's "direct entry" / "keyboard mode" turns the app from a text editor into
+an on-screen input method: the output pane is hidden and text is injected into
+whatever other application the user is working in. Windows and Apple already
+implement this (SendInput, CGEvent posting); GTK implements it via
+`ydotool`/uinput; Android's analogue is the IME (RFC 0008). This RFC writes
+down the cross-platform contract those frontends have converged on — window
+behaviour, availability probing, failure surfacing, delete semantics — so the
+remaining gaps (notably GTK's focus handling) get closed deliberately rather
+than by accident.
+
+## Implementation status
+
+Audited August 2026.
+
+| Platform | State | Notes |
+| --- | --- | --- |
+| Dasher-Windows | Implemented | `SendInput` with `KEYEVENTF_UNICODE`; canvas-only topmost `WS_EX_NOACTIVATE` window with mini-bar and opacity; target-window tracking. `MainWindow.axaml.cs`. |
+| Dasher-Apple (macOS) | Implemented | Accessibility-trusted CGEvent posting to the tracked frontmost app; floating non-activating window, "Sending to \<app\>" indicator. `DirectModeService.swift`, `MacContentView.swift`. |
+| Dasher-Apple (iOS) | Different mechanism | Keyboard extension (`UITextDocumentProxy.insertText/deleteBackward`) — the OS-sanctioned form of direct entry. Onboarding covered by [RFC 0008](./0008-keyboard-onboarding.md). |
+| Dasher-GTK | Partial | `ydotool` injection works; daemon probing + failure surfacing + UTF-8-safe deletes landed in [Dasher-GTK #51](https://github.com/dasher-project/Dasher-GTK/pull/51). **Missing:** keep-above / no-focus window behaviour (GTK4 removed the APIs v5 used — see Detailed design) and per-character rather than whole-string injection on some paths. |
+| Dasher-Android | N/A (IME) | Standalone apps cannot inject input on Android; the IME service *is* direct entry there. |
+| dasher-web | N/A | Browsers cannot inject input across applications. |
+| DasherCore | N/A | Injection is entirely frontend-side; the engine only needs the output callback (`dasher_set_output_callback`, event types 0 insert / 1 delete). |
+
+## Motivation
+
+Direct entry is one of the main ways long-term Dasher users actually run the
+program — v5 GTK had it via XTest ("direct mode"), and Windows users of v6 use
+it daily. But it is also the feature most prone to *silent* failure, because it
+depends on platform permission plumbing that the app cannot assume:
+
+- A v6 first-impressions report (Linux, CachyOS, 2026-08): *"I prefer to type
+  directly into a window. This is probably not implemented yet."* and *"I have
+  no idea what the keyboard button does."* Root cause: GTK's availability check
+  tested for the `ydotool` *binary*, while Arch installs the binary without
+  enabling the `ydotoold` *daemon* — so the mode toggled, the pane collapsed,
+  and nothing was typed, with no error anywhere. (Fixed in Dasher-GTK #51.)
+- macOS requires Accessibility trust; Windows needs no permission but must not
+  steal focus from the target window; GTK must not steal focus either — v5
+  solved this with `gtk_window_set_accept_focus(false)` + keep-above + stick,
+  all removed in GTK4.
+
+Each frontend solved (or didn't solve) these problems independently. The
+behavioural contract should be shared, like other cross-platform UX in RFCs
+0008/0010, so that "enable keyboard mode" behaves recognisably everywhere and
+fails loudly everywhere.
+
+## Detailed design
+
+### The contract (all platforms)
+
+1. **Mode toggle.** One obvious control ("Keyboard" / "Direct Mode"), labelled
+   or tooltiped with *what it does* even when unavailable. Toggling on:
+   - hides the output/editor pane (canvas-only layout, plus a small control
+     strip with at least: leave-mode, settings, pause),
+   - switches output routing from the internal buffer to the injection path —
+     including **deletes**, which must be forwarded as backspaces,
+   - does **not** clear the engine context; the user keeps their sentence.
+   Toggling off restores the normal editor layout.
+
+2. **Window behaviour.** While the mode is on, the Dasher window must not
+   disturb the target application:
+   - stay above / floating,
+   - **never take keyboard focus** on click or hover (the injected keystrokes
+     go to the focused window — if clicking Dasher to steer steals focus,
+     Dasher types into itself),
+   - present on all workspaces/desktops where the platform allows it,
+   - optional user-configurable opacity (Windows/Apple ship 0.2–1.0, default
+     ~0.85) so the canvas doesn't cover the target app.
+
+3. **Availability probing.** The enable control may only report "available"
+   if the *whole injection path* works, not just that a helper binary exists:
+   - macOS: `AXIsProcessTrusted` (offer the prompt variant).
+   - GTK: probe `ydotool` end-to-end (a zero-length relative pointer move
+     exercises socket + daemon + uinput without moving the pointer). Sandboxed
+     Flatpak/AppImage builds report unavailable (`/dev/uinput` is unreachable).
+   - Windows: always available.
+   When unavailable, offer guided setup (Dasher-GTK's setup dialog with
+   distro-specific install commands is the pattern; Apple uses the
+   accessibility-gate screen).
+
+4. **No silent failures.** Every injection call's outcome is checked. If
+   injection fails mid-session (daemon died, permission revoked), the frontend
+   must tell the user and leave the mode (or pause it), never keep swallowing
+   output. Where possible, remember the last non-Dasher target window
+   (Windows `GetForegroundWindow` on deactivate; macOS
+   `NSWorkspace.didActivateApplicationNotification`) and re-aim at it.
+
+5. **Delete semantics.** A delete event (callback event type 1) carries the
+   deleted text; inject one backspace **per character** (code point), never
+   per byte. (Dasher-GTK counted bytes until #51 — "é" deleted two
+   characters.)
+
+6. **Text semantics.** Newline injects Return/Enter, not a literal newline;
+   tab injects Tab where the platform has a keycode. Unicode beyond the
+   platform's keycode space uses the platform's unicode path
+   (`KEYEVENTF_UNICODE`, CGEvent unicode string, `ydotool type`).
+
+7. **Engine interface.** No engine changes are required. Frontends consume
+   `dasher_set_output_callback` events; the engine's edit buffer keeps
+   accumulating regardless (it is simply not displayed), so leaving the mode
+   must not corrupt engine state.
+
+### Platform specifics
+
+- **Windows (shipped).** `SendInput`/`KEYEVENTF_UNICODE`;
+  `WS_EX_NOACTIVATE | WS_EX_LAYERED` + `Topmost` + opacity + mini-bar
+  (`KeyboardMiniBar`); focus restoration to the remembered target via
+  `AttachThreadInput` + `SetForegroundWindow`.
+- **macOS (shipped).** CGEvent unicode events posted to the tracked app's pid
+  (fallback `cghidEventTap`); backspace keycode 51, Return 36; floating,
+  non-activating, all-spaces window; accessibility-gate prompt.
+- **GTK.** Injection via `ydotool` (`type` for strings, `key` for
+  Backspace/Return/Tab), daemon-probed as above. **Open problem:** GTK4
+  removed `gtk_window_set_keep_above`, `set_accept_focus` and `stick` — v5's
+  exact recipe is unavailable. Candidate approaches, to be settled in
+  discussion: (a) X11-only fallback via raw Xlib (`XSetInputFocus` /
+  `_NET_WM_STATE_ABOVE`) when not running under Wayland; (b) accept focus
+  stealing on Wayland and document that the user should start Dasher by
+  hover/click-free input (e.g. socket/eye-tracker drivers that don't require
+  clicking the canvas); (c) pursue a compositor-specific route (KDE
+  layer-shell) as an opt-in. Until then, GTK's mode works but is ergonomically
+  worse than v5 on X11.
+- **Android / visionOS / web.** No standalone direct entry; Android's IME is
+  the equivalent surface (onboarding: RFC 0008).
+
+## Drawbacks
+
+- Codifying window behaviour invites bikeshedding across three windowing
+  systems; the GTK4/Wayland situation genuinely has no clean answer.
+- The contract adds QA surface: each platform needs a "type into another app"
+  manual pass (see Testing).
+- Some clauses (opacity, mini-bar) are cosmetic; enforcing them uniformly may
+  not be worth blocking a frontend that otherwise implements the mode.
+
+## Alternatives considered
+
+- **Leave it per-frontend.** Status quo; produced the GTK silent-failure gap
+  this RFC grew out of, and inconsistent behaviour between platforms.
+- **Implement direct entry in DasherCore.** Rejected: injection is inherently
+  platform plumbing (uinput, CGEvent, SendInput) with no shared code to put in
+  the engine.
+- **Keyboard-extension/IME everywhere.** Only Android and iOS offer it; no
+  desktop OS lets a normal app register as an IME for other apps.
+
+## Prior art
+
+- **Dasher v5 GTK direct mode** — XTest injection + hide editor + keep-above +
+  `accept_focus(false)` + stick (`dasher_main.cpp` `toggle_direct_mode`); the
+  behavioural template for this RFC.
+- **Windows On-Screen Keyboard / Tablet input panel** — `WS_EX_NOACTIVATE`
+  topmost translucent window; the pattern Dasher-Windows follows.
+- **CharaChorder/Keyviz-style tools, ydotool/wtype** — Linux injection
+  helpers; each requires the daemon/permissions probing described here.
+- **RFC 0008** — the IME/keyboard-extension *onboarding* flows; 0015 covers
+  the standalone-app injection mode and cross-references it.
+
+## Testing
+
+Per [RFC 0011](./0011-testing.md). Mixed automated + manual:
+
+- **Automated (frontend):** pure logic that injection depends on is unit
+  tested — GTK's UTF-8 code-point counting lives in
+  `Dasher-GTK/tests/test_direct_mode_service.cpp`; Windows keeps a keyboard
+  debug log (`%APPDATA%/Dasher/keyboard_debug.log`). Frontends that can
+  self-inject (Windows) may assert `SendInput` return values.
+- **Automated (probe):** where a probe is pure (macOS trust-state enum), test
+  the state machine.
+- **Manual verification required** per platform, since injection crosses
+  process boundaries: enable mode → focus a native text app → write a
+  sentence incl. accents/emoji → delete an accented character → confirm
+  exactly one character is removed; kill the daemon/permission mid-session →
+  confirm a visible error and clean exit from the mode. Record the pass in the
+  PR that changes this behaviour.
+
+## Unresolved questions
+
+1. **GTK4/Wayland focus behaviour.** **Open.** X11 Xlib fallback vs
+   documented limitation vs layer-shell — needs GTK maintainer (PapeCoding)
+   input.
+2. **Should the engine expose a "direct mode" flag** so the UI can ask the
+   engine to suppress buffer-based features (speak-on-stop, copy-on-stop)
+   while injecting? **Open.**
+3. **Opacity/mini-bar uniformity.** Required, recommended, or optional?
+   **Open.**
+4. **Wayland text-injection protocol** (`zwp_text_input_v3` is for IMEs;
+   `virtual-keyboard` protocol exists on some compositors) — viable alternative
+   to ydotool on Wayland? **Open.**
+
+## Resolution
+
+- State: pending — open for discussion
+- Decided by: —
+- Date: —
+- Decision: Not yet accepted. Windows and Apple implementations predate the
+  RFC and already conform; GTK conformance is partial (Dasher-GTK #51 closes
+  the probing/failure/delete clauses).
+- Open sub-questions: all (see Unresolved questions).
+
+## History
+
+- _2026-08-21_ — _(initial proposal, growing out of the v6 first-impressions
+  report and Dasher-GTK #51)_

--- a/rfcs/README.md
+++ b/rfcs/README.md
@@ -76,3 +76,4 @@ means "landed on some platforms, not all."
 | [0012](./0012-typing-rate.md) | Typing rate (CPS / WPM) display | implemented | apple, windows, gtk, android, core |
 | [0013](./0013-custom-rendering.md) | Node-tree rendering API (custom rendering) | active | apple, windows, gtk, android, web, core |
 | [0014](./0014-image-labels.md) | Image labels for alphabet symbols | implemented | apple, windows, gtk, android, web, core |
+| [0015](./0015-direct-entry-mode.md) | Direct-entry mode (typing into other applications) | proposed | apple, windows, gtk, android, core |


### PR DESCRIPTION
Grows out of a v6 first-impressions report from a long-time v5 Linux user ("I prefer to type directly into a window", "no idea what the keyboard button does", speed 5.0 unreachable, New not resetting context) and the resulting [Dasher-GTK #51](https://github.com/dasher-project/Dasher-GTK/pull/51).

## RFC 0015 — Direct-entry mode (status: proposed)

Windows and Apple independently converged on a good direct-entry design; GTK had the feature but failed silently (probed for the ydotool binary, not the daemon; swallowed all injection errors; byte-based deletes). The RFC writes down the de-facto contract so the rest gets closed deliberately:

- Mode toggle semantics (canvas-only layout, keep engine context)
- Window behaviour while active: topmost, **never steals focus**, all workspaces, optional opacity — with the Windows (`WS_EX_NOACTIVATE` + `Topmost`) and Apple (floating non-activating panel) prior art
- Availability probing must exercise the **whole injection path** (daemon/permissions), not just binary presence; guided setup when unavailable
- **No silent failures** — checked outcomes, visible error, clean exit from the mode
- Deletes are per **character**, not byte (Dasher-GTK bug: "é" deleted two chars)
- Platform notes incl. the open GTK4/Wayland problem (GTK4 removed keep-above/accept-focus that v5 used) — flagged for PapeCoding's input; Android covered by the IME (RFC 0008)

Per governance process this is step 2 (RFC created) — 7 days minimum before consensus.

## RFC 0005 — Behaviour parity beyond settings (in-place edit + History)

Two lessons that aren't settings migration per se but bite migrating v5 users:

1. **Speed UI ranges must accept raw 10–800** (v5's full range; the `dasher_set_speed_percent` helper clamps to raw 640, so migration must write `LP_MAX_BITRATE` directly). Dasher-GTK's footer capped at 400 until #51.
2. **"New" = `dasher_reset()`** (text + context), matching v5's `SetBuffer(0)`; `dasher_reset_output_text()` is only for Open-file.

## Also considered

- Direct-entry window-management details for GTK4/Wayland stay as unresolved questions rather than prescriptions, since there is genuinely no clean cross-compositor answer.

DCO signed. Ping: @PapeCoding (GTK clauses), review welcome from all maintainers.
