### PR TITLE
docs(rfcs): 0016 Windows implemented; 0015 Windows delete forwarding landed

### DIFF
--- a/rfcs/0015-direct-entry-mode.md
+++ b/rfcs/0015-direct-entry-mode.md
@@ -27,7 +27,7 @@ Audited August 2026.
 
 | Platform | State | Notes |
 | --- | --- | --- |
-| Dasher-Windows | Implemented | `SendInput` with `KEYEVENTF_UNICODE`; canvas-only topmost `WS_EX_NOACTIVATE` window with mini-bar and opacity; target-window tracking. `MainWindow.axaml.cs`. |
+| Dasher-Windows | Implemented | `SendInput` with `KEYEVENTF_UNICODE` (VK_BACK for deletes — one per code point, output-callback driven since Aug 2026); canvas-only topmost `WS_EX_NOACTIVATE` window with mini-bar and opacity; target-window tracking. `MainWindow.axaml.cs`. |
 | Dasher-Apple (macOS) | Implemented | Accessibility-trusted CGEvent posting to the tracked frontmost app; floating non-activating window, "Sending to \<app\>" indicator. `DirectModeService.swift`, `MacContentView.swift`. |
 | Dasher-Apple (iOS) | Different mechanism | Keyboard extension (`UITextDocumentProxy.insertText/deleteBackward`) — the OS-sanctioned form of direct entry. Onboarding covered by [RFC 0008](./0008-keyboard-onboarding.md). |
 | Dasher-GTK | Partial | `ydotool` injection works; daemon probing + failure surfacing + UTF-8-safe deletes landed in [Dasher-GTK #51](https://github.com/dasher-project/Dasher-GTK/pull/51). **Missing:** keep-above / no-focus window behaviour (GTK4 removed the APIs v5 used — see Detailed design) and per-character rather than whole-string injection on some paths. |
@@ -212,5 +212,5 @@ Per [RFC 0011](./0011-testing.md). Mixed automated + manual:
 
 ## History
 
-- _2026-08-21_ — _(initial proposal, growing out of the v6 first-impressions
-  report and Dasher-GTK #51)_
+- _2026-08-21_ — _(initial proposal, growing out of the v6 first-impressions report and Dasher-GTK #51)_
+- _2026-08-24_ — _(Windows: deletions now forwarded from engine output events (one backspace per code point, event-2 clears resync without injecting), closing the gap reported in [Dasher-Windows #26](https://github.com/dasher-project/Dasher-Windows/issues/26))_

--- a/rfcs/0016-version-in-settings.md
+++ b/rfcs/0016-version-in-settings.md
@@ -23,7 +23,7 @@ analytics opt-in.
 | --- | --- | --- |
 | Dasher-GTK | Implemented | `Preferences → Privacy`, `DASHER_GTK_VERSION` compile definition (same source analytics already uses). |
 | Dasher-Android | Implemented | `Settings → Privacy`, `BuildConfig.VERSION_NAME` (same source analytics already uses). |
-| Dasher-Windows | Issue filed | Version exists in analytics + update checks; needs the Settings row. |
+| Dasher-Windows | Implemented | `Settings → Privacy`, bottom line; `UpdateChecker.GetCurrentVersion()` — the same source analytics and update checks already use. |
 | Dasher-Apple | Issue filed | Version exists in analytics; needs the Settings row (macOS/iOS/visionOS). |
 | dasher-web | Issue filed | Needs the row in its settings surface. |
 
@@ -121,3 +121,8 @@ assertion would restate the code.
   the remaining frontends. Placement in Privacy is explicitly interim pending
   RFC 0006's About section.
 - Open sub-questions: 1, 2 (engine version display; build metadata).
+
+## History
+
+- _2026-08-22_ — _(initial proposal; accepted directly, GTK and Android implemented immediately, issues filed for the remaining frontends)_
+- _2026-08-24_ — _(Windows implemented — version line at the bottom of Settings → Privacy, closing [Dasher-Windows #29](https://github.com/dasher-project/Dasher-Windows/issues/29))_


### PR DESCRIPTION
﻿## Summary

Status updates for Windows implementations landing in the Dasher-Windows stack (#30–#33):

- **RFC 0016** (version in Settings): Dasher-Windows row → **Implemented** — version line at the bottom of `Settings → Privacy`, sourced from `UpdateChecker.GetCurrentVersion()` (same constant analytics reports). History entry added. (Dasher-Windows #29 / PR #31)
- **RFC 0015** (direct-entry): Windows implementation-status note updated — deletes are now forwarded from engine output events (one backspace per code point; buffer-clear events resync without injecting), closing Dasher-Windows #26 / PR #30. History entry added.

RFC 0015 remains `proposed` — this only updates the per-platform table + history, per "Keeping RFCs current".

Issue / RFC: Dasher-Windows #26, #29

## Type of change

- [ ] Bug fix
- [ ] New feature
- [ ] Cross-platform / parity change
- [x] Refactor / tooling / docs

## Cross-platform impact

- [ ] This changes a capability that users see on **other platforms**.
- [ ] This introduces a **new UX or hardware interaction**.

## Definition of Done

- [x] CI is green (docs-only)
- [x] Tests added for new behaviour (n/a)
- [x] Feature matrix updated if this affects a cross-platform capability (n/a)
- [x] Docs / changelog updated if the change is user-facing (this *is* the docs change)
- [x] Commits are signed off (DCO) - `git commit -s`
