### PR TITLE
rfc(0012): typing rate in direct-entry mode; Windows status update

### DIFF
--- a/rfcs/0012-typing-rate.md
+++ b/rfcs/0012-typing-rate.md
@@ -4,7 +4,7 @@ title: Typing rate (CPS / WPM) display
 status: implemented
 platforms: [apple, windows, gtk, android, core]
 created: 2026-07-18
-updated: 2026-08-01
+updated: 2026-08-26
 ---
 
 # Typing rate (CPS / WPM) display
@@ -26,7 +26,7 @@ Audited August 2026. The engine layer is done. DasherCore exposes
 | --- | --- | --- |
 | Dasher-Apple (iOS, macOS) | Implemented | Live WPM, max, and average in the canvas overlay and in game mode; a Settings toggle (`showTypingRate`). CPS is not shown; only WPM. |
 | dasher-web | Implemented | Own JS engine; live WPM, peak WPM, and accuracy. Does not consume the DasherCore C API. |
-| Dasher-Windows | Not started | No WPM or CPS display. |
+| Dasher-Windows | Implemented | Status-bar WPM/max/avg (Settings → Output, `ShowTypingRate`); live WPM in the Direct Mode mini-bar (compact form). |
 | Dasher-GTK | Not started | The bundled DasherCore predates `dasher_get_wpm`. |
 | Dasher-Mobile (Android) | Not started | The bundled DasherCore fork predates this feature. |
 
@@ -93,6 +93,14 @@ Cost: a DasherCore addition + submodule bump.
   (group: "Output", or a small "Statistics" group — per RFC 0006 IA). When on,
   a small CPS/WPM badge in the toolbar or a canvas corner. **Off by default**
   so it doesn't clutter the main writing view.
+- **Direct-entry mode (opt-in, same setting):** frontends that hide their
+  normal chrome in direct-entry mode (Windows' mini-bar, Apple's floating
+  window) show a **compact live-WPM** element in the mode's control strip
+  when the typing-rate toggle is on. Compact = current rate only (no max/avg)
+  — the strip has no room for more, and the audience for this surface
+  (therapist/user live feedback) needs the current number. Added August 2026
+  after a Windows user request; the IME surfaces (Android keyboard extension)
+  are exempt for now (no persistent strip; revisit with RFC 0008 flows).
 - Format e.g. `4.2 cps · 50 wpm`; labels localised per RFC 0003.
 
 ### Privacy
@@ -161,3 +169,5 @@ Per [RFC 0011](./0011-testing.md):
 ## History
 
 - 2026-07-18 — initial proposal.
+- 2026-08-01 — implemented (engine API + Apple/web); window/pause/toggle decisions recorded above.
+- 2026-08-26 — direct-entry-mode clause added (compact live WPM in the Direct Mode control strip, same opt-in setting; Windows user request); Windows status row updated to Implemented (status-bar + mini-bar).


### PR DESCRIPTION
﻿Amends RFC 0012 (typing-rate display) per a Windows user request: WPM in Direct Mode.

- **UI section:** new "Direct-entry mode (opt-in, same setting)" clause — compact live WPM (current rate only) in the direct-mode control strip; IME surfaces exempt for now. Edit-in-place + dated history entry per the RFC-editing rules.
- **Status table:** Dasher-Windows row was stale ("Not started") — updated to Implemented (status-bar WPM/max/avg shipped earlier; mini-bar WPM landing with the companion Dasher-Windows PR that bumps DasherCore to v0.2.7).

Cross-platform note for other maintainers: Apple's floating direct-mode window should adopt the same compact element when convenient (the clause is written platform-neutral).
